### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "webdevstudios/cmb2",
+    "description": "Custom Metaboxes and Fields (CMB) will create metaboxes and forms with custom fields that will blow your mind.",
+    "license": "GPLv2",
+    "homepage": "https://github.com/WebDevStudios/CMB2",
+    "keywords": ["wordpress", "metabox"],
+    "authors": [
+        {
+            "name": "WebDev Studios",
+            "email": "contact@webdevstudios.com",
+            "homepage": "http://webdevstudios.com"
+        },
+        {
+            "name": "Justin Sternberg",
+            "email": "me@jtsternberg.com",
+            "homepage": "http://dsgnwrks.pro"
+        }
+    ],
+    "require": {
+    }
+}


### PR DESCRIPTION
This should fix #19.

Once this is merged, people should be allowed to include this package with the [VCS config](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository).

Ideally, you could then [submit](https://packagist.org/packages/submit) the package to Packagist (the Composer central repo), so people don't need to use the VCS config (more informations [here](https://packagist.org/about)). That's not something I can do, as it requires the repo's maintainer to open an account to submit the package.
