### PR TITLE
update styles/scripts methods to prevent conflict with CMB

### DIFF
--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -136,11 +136,11 @@ class CMB2_hookup {
 		// styles required for cmb
 		$styles = array( 'wp-color-picker' );
 
-		wp_register_script( 'cmb-scripts', cmb2_utils()->url( "js/cmb2{$min}.js" ), $scripts, CMB2_VERSION );
+		wp_register_script( 'cmb2-scripts', cmb2_utils()->url( "js/cmb2{$min}.js" ), $scripts, CMB2_VERSION );
 
 		wp_enqueue_media();
 
-		wp_localize_script( 'cmb-scripts', 'cmb2_l10', apply_filters( 'cmb2_localized_data', array(
+		wp_localize_script( 'cmb2-scripts', 'cmb2_l10', apply_filters( 'cmb2_localized_data', array(
 			'ajax_nonce'       => wp_create_nonce( 'ajax_nonce' ),
 			'ajaxurl'          => admin_url( '/admin-ajax.php' ),
 			'script_debug'     => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
@@ -182,7 +182,7 @@ class CMB2_hookup {
 			),
 		) ) );
 
-		wp_register_style( 'cmb-styles', cmb2_utils()->url( "css/cmb2{$min}.css" ), $styles );
+		wp_register_style( 'cmb2-styles', cmb2_utils()->url( "css/cmb2{$min}.css" ), $styles );
 
 		self::$registration_done = true;
 	}
@@ -355,7 +355,7 @@ class CMB2_hookup {
 	public static function enqueue_cmb_css() {
 		CMB2_hookup::register_scripts();
 
-		return wp_enqueue_style( 'cmb-styles' );
+		return wp_enqueue_style( 'cmb2-styles' );
 	}
 
 	/**
@@ -365,7 +365,7 @@ class CMB2_hookup {
 	public static function enqueue_cmb_js() {
 		CMB2_hookup::register_scripts();
 
-		return wp_enqueue_script( 'cmb-scripts' );
+		return wp_enqueue_script( 'cmb2-scripts' );
 	}
 
 }


### PR DESCRIPTION
When using CMB2 alongside CMB, CMB2 styles/scripts are overridden. 
