### PR TITLE
Prevent autoloading before autoloader is setup

### DIFF
--- a/init.php
+++ b/init.php
@@ -39,7 +39,7 @@
                   or things might explode!
 *************************************************************************/
 
-if ( ! class_exists( 'cmb2_bootstrap_200beta' ) ) {
+if ( ! class_exists( 'cmb2_bootstrap_200beta', false ) ) {
 
 	/**
 	 * Check for newest version of CMB
@@ -76,7 +76,7 @@ if ( ! class_exists( 'cmb2_bootstrap_200beta' ) ) {
 		}
 
 		public function include_cmb() {
-			if ( ! class_exists( 'CMB2' ) ) {
+			if ( ! class_exists( 'CMB2', false ) ) {
 				if ( ! defined( 'CMB2_VERSION' ) ) {
 					define( 'CMB2_VERSION', self::VERSION );
 				}


### PR DESCRIPTION
Since the autoloader hasn't been loaded yet, prevent autoloading in the `if ( class_exists() )` checks.
