### PR TITLE
Improve field arguments to make files always accessible by ID

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -811,8 +811,8 @@ class CMB2_Types {
 		$this->field = new CMB2_Field( array(
 			'field_args'  => $args,
 			'group_field' => $this->field->group,
-			'object_type' => $this->field->object_type(),
-			'object_id'   => $this->field->object_id(),
+			'object_type' => $this->field->object_type,
+			'object_id'   => $this->field->object_id,
 		) );
 
 		// Get ID value


### PR DESCRIPTION
BUGREPORT
$this->field->object_type() : expected return -> (custom) Posttype : actual return -> false (always)
$this->field->object_id() :  expected return -> (custom) Post-ID : actual return -> false (always)
both methods are not implemented,  __call fallback accesses wrong properties
Postmeta READ always fails (no ID/type), fallback using GUID fails on edited/moved attachments
http://pods.io/2013/07/17/dont-use-the-guid-field-ever-ever-ever/  
RESULT: missing images on e.g. edit.php ( for GUID != filename ) 
FIX: replace function calls with simple properties
