### PR TITLE
Normalize paths in cmb2_dir due to failing unit tests on Windows

### DIFF
--- a/CMB2.php
+++ b/CMB2.php
@@ -7,7 +7,7 @@
  * @return string        Directory with optional path appended
  */
 function cmb2_dir( $path = '' ) {
-	return trailingslashit( dirname( __FILE__ ) ) . $path;
+	return wp_normalize_path( trailingslashit( dirname( __FILE__ ) ) . $path );
 }
 
 require_once cmb2_dir( 'includes/helper-functions.php' );


### PR DESCRIPTION
Normalizing paths keeps the slashes straight across environments
