### PR TITLE
Failing unit test on WYSIWYG field type due to hard coded URL

### DIFF
--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -111,13 +111,16 @@ class CMB2_Types_Test extends CMB2_Test {
 		$field = cmb2_get_field( $this->field_test['id'], 'field_test_field', $this->post_id );
 		$this->assertInstanceOf( 'CMB2_Field', $field );
 
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+		$version = 'ver=' . $wp_version;
+
 		$field_gen = '
 		<div class="cmb-row cmb-type-wysiwyg cmb2-id-field-test-field">
 			<div class="cmb-td">
 				<label for="field_test_field">Name</label>
 				<div id="wp-field_test_field-wrap" class="wp-core-ui wp-editor-wrap html-active">
-					<link rel=\'stylesheet\' id=\'dashicons-css\' href=\'http://example.org/wp-includes/css/dashicons.min.css?ver='. $wp_version .'\' type=\'text/css\' media=\'all\' />
-					<link rel=\'stylesheet\' id=\'editor-buttons-css\' href=\'http://example.org/wp-includes/css/editor.min.css?ver='. $wp_version .'\' type=\'text/css\' media=\'all\' />
+					<link rel=\'stylesheet\' id=\'dashicons-css\' href=\'' . includes_url( "css/dashicons$suffix.css?$version" ) . '\' type=\'text/css\' media=\'all\' />
+					<link rel=\'stylesheet\' id=\'editor-buttons-css\' href=\'' . includes_url( "css/editor$suffix.css?$version" ) . '\' type=\'text/css\' media=\'all\' />
 					<div id="wp-field_test_field-editor-container" class="wp-editor-container">
 						<textarea class="wp-editor-area" rows="20" cols="40" name="field_test_field" id="field_test_field">
 						</textarea>


### PR DESCRIPTION
Modeled the code after the actual `_WP_Editors` class code that is generating the HTML for the WYSIWYG box.

https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-editor.php#L509-L511
