### PR TITLE
Make get_object_terms work with and without object caching.

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -608,7 +608,7 @@ class CMB2_Types {
 	public function taxonomy_select() {
 
 		$names      = $this->get_object_terms();
-		$saved_term = is_wp_error( $names ) || empty( $names ) ? $this->field->args( 'default' ) : $names[0]->slug;
+		$saved_term = is_wp_error( $names ) || empty( $names ) ? $this->field->args( 'default' ) : $names[key($names)]->slug;
 		$terms      = get_terms( $this->field->args( 'taxonomy' ), 'hide_empty=0' );
 		$options    = '';
 
@@ -666,7 +666,7 @@ class CMB2_Types {
 
 	public function taxonomy_radio() {
 		$names      = $this->get_object_terms();
-		$saved_term = is_wp_error( $names ) || empty( $names ) ? $this->field->args( 'default' ) : $names[0]->slug;
+		$saved_term = is_wp_error( $names ) || empty( $names ) ? $this->field->args( 'default' ) : $names[key($names)]->slug;
 		$terms      = get_terms( $this->field->args( 'taxonomy' ), 'hide_empty=0' );
 		$options    = ''; $i = 1;
 


### PR DESCRIPTION
When `get_object_terms` resorts to using `get_the_terms`, `get_object_term_cache` is called.
The data stored by `update_object_term_cache` is an associative array, the key being the term id.
This causes `$name[0]->slug` to attempt to access an array item that doesn't exist.
This PR makes use of the `key` function to get the first item from the array regardless of whether it's associative or not.
