### PR TITLE
add new and shift triggers

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -367,6 +367,7 @@ window.CMB2 = (function(window, document, $, undefined){
 	};
 
 	cmb.afterRowInsert = function( $row, group ) {
+			
 		var $focus = $row.find('input:not([type="button"]), textarea, select').first();
 		if ( $focus.length ) {
 			if ( group ) {
@@ -446,6 +447,10 @@ window.CMB2 = (function(window, document, $, undefined){
 		event.preventDefault();
 
 		var $self    = $(this);
+		
+		// before anything significant happens
+		$self.trigger( 'cmb2_add_group_row_start', $self );
+		
 		var $table   = $('#'+ $self.data('selector'));
 		var $oldRow  = $table.find('.cmb-repeatable-grouping').last();
 		var prevNum  = parseInt( $oldRow.data('iterator') );
@@ -458,7 +463,7 @@ window.CMB2 = (function(window, document, $, undefined){
 		$oldRow.after( $newRow );
 
 		cmb.afterRowInsert( $newRow, true );
-
+		
 		if ( $table.find('.cmb-repeatable-grouping').length <= 1  ) {
 			$table.find('.cmb-remove-group-row').prop( 'disabled', true );
 		} else {
@@ -504,6 +509,9 @@ window.CMB2 = (function(window, document, $, undefined){
 		var number  = $table.find('.cmb-repeatable-grouping').length;
 
 		if ( number > 1 ) {
+		    
+			$table.trigger( 'cmb2_remove_group_row_start', $self );
+			
 			// when a group is removed loop through all next groups and update fields names
 			$parent.nextAll( '.cmb-repeatable-grouping' ).find( cmb.repeatEls ).each( cmb.updateNameAttr );
 
@@ -552,12 +560,18 @@ window.CMB2 = (function(window, document, $, undefined){
 		event.preventDefault();
 
 		var $self     = $(this);
+		// before anything signif happens
+		$self.trigger( 'cmb2_shift_rows_enter', $self );
+
 		var $parent   = $self.parents( '.cmb-repeatable-grouping' );
 		var $goto     = $self.hasClass( 'move-up' ) ? $parent.prev( '.cmb-repeatable-grouping' ) : $parent.next( '.cmb-repeatable-grouping' );
 
 		if ( ! $goto.length ) {
 			return;
 		}
+
+		// we're gonna shift
+		$self.trigger( 'cmb2_shift_rows_start', $self );		
 
 		var inputVals = [];
 		// Loop this items fields
@@ -605,6 +619,9 @@ window.CMB2 = (function(window, document, $, undefined){
 				$element.val( inputVals[ index ]['val'] );
 			}
 		});
+		
+		// shift done
+		$self.trigger( 'cmb2_shift_rows_complete', $self );
 	};
 
 	cmb.initPickers = function( $timePickers, $datePickers, $colorPickers ) {


### PR DESCRIPTION
I'm working on getting the select2 field type working in a repeat group. in order to do so, i needed these triggers. 

note: some of the background / solution w/ regards to select2 can be found here:

https://github.com/mustardBees/cmb-field-select2/issues/10

once these are merged, i'll do a PR for the select2 fixes as well. 

p.s. I read somewhere that WP was going to (for lack of a better word) embrace select2 in a future release. perhaps it would make sense for CMB2 to have select2 as native sooner rather than later? just a thought. 
