### PR TITLE
Fix for the bug that caused rendering an extra select dropdown for select fields when repeatable is set to true

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -310,6 +310,9 @@ class CMB2_Types {
 			$meta_value = $default;
 		}
 
+		// fix the empty select dropdown bug when the repeatable is set to 'true' for a 'select' type
+		if($this->field->type()=="select" && $this->field->args("repeatable")==true && is_array($meta_value)) array_pop($meta_value);
+				
 		// Loop value array and add a row
 		if ( ! empty( $meta_value ) ) {
 			$count = count( $meta_value );


### PR DESCRIPTION
CMB2 has a strange bug that creates an extra "select" dropdown field when the "repeatable" argument is set to true for a "select" field and it has more than 1 values. In simple, if a select field has been repeated N times where N>1, this bug always renders an extra select dropdown at the end.

This bug is only related to "select" fields, specially when their "repeatable" is set to true. Doesn't affect other fields.
