### PR TITLE
Fix issue with on_front or show_on_cb

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -432,6 +432,11 @@ class CMB2_Field {
 		$meta_value = isset( $data_to_save[ $this->id( true ) ] )
 			? $data_to_save[ $this->id( true ) ]
 			: null;
+			
+		//Return if value not exist in current submission
+		if ( is_null( $meta_value ) ) {
+			return;
+		}			
 
 		return $this->save_field( $meta_value );
 	}


### PR DESCRIPTION
If have one form in backend, and with help of on_front or show_on_cb, display it partially at frontend, the fields\meta that not displayed, and not exist in submission, are removed during submit process. For group field exist [proper check](https://github.com/WebDevStudios/CMB2/blob/master/includes/CMB2.php#L481), but usual fields not have some, that is fixed by PR.
