### PR TITLE
Refresh CMB2/feature/nested-fields-trunk with latest

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -588,11 +588,7 @@ class CMB2 extends CMB2_Field_Group {
 				$field_object->args['show_names'] = $this->get_show_names();
 
 				// Render default fields
-				// Todo: Hacked the same way get_field() was to update field values that may have changed since instantiation
-				$field_object->object_id = $this->object_id;
-				$field_object->object_type = $this->object_type;
 				$field_object->escaped_value = null;
-				$field_object->value = $field_object->get_data();
 				$field_object->render_field();
 			}
 		}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -587,7 +587,7 @@ class CMB2 extends CMB2_Field_Group {
 
 				$field_object->args['show_names'] = $this->get_show_names();
 
-				// Render default fields
+				// Todo: escaped_value could be caching old data, revisit
 				$field_object->escaped_value = null;
 				$field_object->render_field();
 			}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -31,7 +31,7 @@ class CMB2 extends CMB2_Field_Group {
 	 * @var   string
 	 * @since 2.0.0
 	 */
-	protected $cmb_id = '';
+	protected $id = '';
 
 	protected $title = '';
 
@@ -118,7 +118,7 @@ class CMB2 extends CMB2_Field_Group {
 		$meta_box = wp_parse_args( $meta_box, $this->mb_defaults );
 		$this->object_id( $object_id );
 
-		$this->set_cmb_id( $meta_box[ 'id' ] );
+		$this->set_id( $meta_box[ 'id' ] );
 		$this->set_title( $meta_box[ 'title' ] );
 		$this->set_type( $meta_box[ 'type' ] );
 		$this->set_object_types( $meta_box[ 'object_types' ] );
@@ -146,26 +146,26 @@ class CMB2 extends CMB2_Field_Group {
 		 *
 		 * @param array $cmb This CMB2 object
 		 */
-		do_action( "cmb2_init_{$this->get_cmb_id()}", $this );
+		do_action( "cmb2_init_{$this->get_id()}", $this );
 	}
 
 	/**
 	 * @return string
 	 */
-	public function get_cmb_id() {
+	public function get_id() {
 
-		return $this->cmb_id;
+		return $this->id;
 	}
 
 	/**
-	 * @param string $cmb_id
+	 * @param string $id
 	 *
 	 * @return string
 	 */
-	public function set_cmb_id( $cmb_id ) {
+	public function set_id( $id ) {
 
-		$this->cmb_id = $cmb_id;
-		return $cmb_id;
+		$this->id = $id;
+		return $id;
 	}
 
 	/**
@@ -545,7 +545,7 @@ class CMB2 extends CMB2_Field_Group {
 		 *	                           Could also be `comment`, `user` or `options-page`.
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( 'cmb2_before_form', $this->get_cmb_id(), $object_id, $object_type, $this );
+		do_action( 'cmb2_before_form', $this->get_id(), $object_id, $object_type, $this );
 
 		/**
 		 * Hook before form table begins
@@ -560,9 +560,9 @@ class CMB2 extends CMB2_Field_Group {
 		 * @param int    $object_id   The ID of the current object
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( "cmb2_before_{$object_type}_form_{$this->get_cmb_id()}", $object_id, $this );
+		do_action( "cmb2_before_{$object_type}_form_{$this->get_id()}", $object_id, $this );
 
-		echo '<div class="cmb2-wrap form-table"><div id="cmb2-metabox-', sanitize_html_class( $this->get_cmb_id() ), '" class="cmb2-metabox cmb-field-list">';
+		echo '<div class="cmb2-wrap form-table"><div id="cmb2-metabox-', sanitize_html_class( $this->get_id() ), '" class="cmb2-metabox cmb-field-list">';
 
 		foreach( $this->get_field_objects() as $field_object ) {
 
@@ -611,7 +611,7 @@ class CMB2 extends CMB2_Field_Group {
 		 *	                           Could also be `comment`, `user` or `options-page`.
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( 'cmb2_after_form', $this->get_cmb_id(), $object_id, $object_type, $this );
+		do_action( 'cmb2_after_form', $this->get_id(), $object_id, $object_type, $this );
 
 		/**
 		 * Hook after form form has been rendered
@@ -625,7 +625,7 @@ class CMB2 extends CMB2_Field_Group {
 		 * @param int    $object_id   The ID of the current object
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( "cmb2_after_{$object_type}_form_{$this->get_cmb_id()}", $object_id, $this );
+		do_action( "cmb2_after_{$object_type}_form_{$this->get_id()}", $object_id, $this );
 
 		echo "\n<!-- End CMB2 Fields -->\n";
 
@@ -741,7 +741,7 @@ class CMB2 extends CMB2_Field_Group {
 
 		switch ( $property ) {
 			case 'id':
-				return $this->get_cmb_id();
+				return $this->get_id();
 
 			case 'title':
 				return $this->get_title();
@@ -836,7 +836,7 @@ class CMB2 extends CMB2_Field_Group {
 		if ( $this->generated_nonce ) {
 			return $this->generated_nonce;
 		}
-		$this->generated_nonce = sanitize_html_class( 'nonce_' . basename( __FILE__ ) . $this->get_cmb_id() );
+		$this->generated_nonce = sanitize_html_class( 'nonce_' . basename( __FILE__ ) . $this->get_id() );
 		return $this->generated_nonce;
 	}
 
@@ -851,12 +851,12 @@ class CMB2 extends CMB2_Field_Group {
 		switch ( $field ) {
 
 			case 'cmb_id':
-				return $this->get_cmb_id();
+				return $this->get_id();
 
 			case 'meta_box':
 				return array_merge(
 					array(
-						'id'               => $this->get_cmb_id(),
+						'id'               => $this->get_id(),
 						'title'            => $this->get_title(),
 						'type'             => $this->get_type(),
 						'object_types'     => $this->get_object_types(),

--- a/includes/CMB2_Boxes.php
+++ b/includes/CMB2_Boxes.php
@@ -27,7 +27,7 @@ class CMB2_Boxes {
 	 * @param CMB2 $cmb_instance CMB2 instance.
 	 */
 	public static function add( CMB2 $cmb_instance ) {
-		self::$cmb2_instances[ $cmb_instance->get_cmb_id() ] = $cmb_instance;
+		self::$cmb2_instances[ $cmb_instance->get_id() ] = $cmb_instance;
 	}
 
 	/**

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -292,8 +292,8 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		if ( $this->group ) {
 
-			$data = is_array( $data ) && isset( $data[ $this->group->index ][ $this->args( 'id' ) ] )
-				? $data[ $this->group->index ][ $this->args( 'id' ) ]
+			$data = is_array( $data ) && isset( $data[ $this->group->index ][ $this->id() ] )
+				? $data[ $this->group->index ][ $this->id() ]
 				: false;
 		}
 

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -233,8 +233,8 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		if ( $this->group ) {
 
-			$data = is_array( $data ) && isset( $data[ $this->group->index ][ $this->args( '_id' ) ] )
-				? $data[ $this->group->index ][ $this->args( '_id' ) ]
+			$data = is_array( $data ) && isset( $data[ $this->group->index ][ $this->args( 'id' ) ] )
+				? $data[ $this->group->index ][ $this->args( 'id' ) ]
 				: false;
 		}
 

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -139,13 +139,25 @@ class CMB2_Field extends CMB2_Field_Group {
 
 	/**
 	 * Retrieves the field id
+	 *
 	 * @since  1.1.0
-	 * @param  boolean $raw Whether to retrieve pre-modidifed id
-	 * @return string       Field id
+	 *
+	 * @param  boolean $html Whether to retrieve the id for use as an html
+	 *                       attribute
+	 *
+	 * @return string  Field id
 	 */
-	public function id( $raw = false ) {
-		$id = $raw ? '_id' : 'id';
-		return $this->args( $id );
+	public function id( $html = false ) {
+
+		$value = null;
+
+		if ( $html ) {
+			$value = $this->get_html_id_attribute();
+		} else {
+			$value = $this->args( 'id' );
+		}
+
+		return $value;
 	}
 
 	/**

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -178,10 +178,6 @@ class CMB2_Field extends CMB2_Field_Group {
 	 */
 	public function get_data( $field_id = '', $args = array() ) {
 
-		if ( 'group' == $this->type() ) {
-			return $this->value();
-		}
-
 		if ( $field_id ) {
 			$args['field_id'] = $field_id;
 		} else if ( $this->group ) {
@@ -742,7 +738,7 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		$style = ! $this->args( 'show_names' ) ? ' style="display:none;"' : '';
 
-		return sprintf( "\n" . '<label%1$s for="%2$s">%3$s</label>' . "\n", $style, $this->id(), $this->args( 'name' ) );
+		return sprintf( "\n" . '<label%1$s for="%2$s">%3$s</label>' . "\n", $style, $this->args( '_id' ), $this->args( 'name' ) );
 	}
 
 	/**
@@ -768,7 +764,7 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		$conditional_classes = array(
 			'cmb-type-' . str_replace( '_', '-', sanitize_html_class( $this->type() ) ) => true,
-			'cmb2-id-' . str_replace( '_', '-', sanitize_html_class( $this->id() ) )    => true,
+			'cmb2-id-' . str_replace( '_', '-', sanitize_html_class( $this->args( '_id' ) ) )    => true,
 			'cmb-repeat'             => $this->args( 'repeatable' ),
 			'cmb-repeat-group-field' => $this->group,
 			'cmb-inline'             => $this->args( 'inline' ),
@@ -963,7 +959,7 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		if ( $this->group ) {
 
-			$args['id']    = $this->group->args( 'id' ) . '_' . $this->group->index . '_' . $args['id'];
+			$args['_id']    = $this->group->args( 'id' ) . '_' . $this->group->index . '_' . $args['id'];
 			$args['_name'] = $this->group->args( 'id' ) . '[' . $this->group->index . '][' . $args['_name'] . ']';
 		}
 

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -118,7 +118,7 @@ class CMB2_Field extends CMB2_Field_Group {
 				break;
 
 			default:
-				$value = $this->{$name};
+				$value = parent::__get( $name );
 				break;
 		}
 

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -785,7 +785,7 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		$style = ! $this->args( 'show_names' ) ? ' style="display:none;"' : '';
 
-		return sprintf( "\n" . '<label%1$s for="%2$s">%3$s</label>' . "\n", $style, $this->args( '_id' ), $this->args( 'name' ) );
+		return sprintf( "\n" . '<label%1$s for="%2$s">%3$s</label>' . "\n", $style, $this->get_html_id_attribute(), $this->args( 'name' ) );
 	}
 
 	/**
@@ -811,7 +811,7 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		$conditional_classes = array(
 			'cmb-type-' . str_replace( '_', '-', sanitize_html_class( $this->type() ) ) => true,
-			'cmb2-id-' . str_replace( '_', '-', sanitize_html_class( $this->args( '_id' ) ) )    => true,
+			'cmb2-id-' . str_replace( '_', '-', sanitize_html_class( $this->get_html_id_attribute() ) )    => true,
 			'cmb-repeat'             => $this->args( 'repeatable' ),
 			'cmb-repeat-group-field' => $this->group,
 			'cmb-inline'             => $this->args( 'inline' ),
@@ -1001,18 +1001,9 @@ class CMB2_Field extends CMB2_Field_Group {
 			'remove_button' => __( 'Remove Group', 'cmb2' ),
 		) ) : $args['options'];
 
-		$args['_id']        = $args['id'];
-		$args['_name']      = $args['id'];
-
-		if ( $this->group ) {
-
-			$args['_id']    = $this->group->args( 'id' ) . '_' . $this->group->index . '_' . $args['id'];
-			$args['_name'] = $this->group->args( 'id' ) . '[' . $this->group->index . '][' . $args['_name'] . ']';
-		}
-
 		if ( 'wysiwyg' == $args['type'] ) {
 			$args['id'] = strtolower( str_ireplace( '-', '_', $args['id'] ) );
-			$args['options']['textarea_name'] = $args['_name'];
+			$args['options']['textarea_name'] = $this->get_html_name_attribute();
 		}
 
 		$option_types = apply_filters( 'cmb2_all_or_nothing_types', array( 'select', 'radio', 'radio_inline', 'taxonomy_select', 'taxonomy_radio', 'taxonomy_radio_inline' ), $this );

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1003,7 +1003,6 @@ class CMB2_Field extends CMB2_Field_Group {
 
 		if ( 'wysiwyg' == $args['type'] ) {
 			$args['id'] = strtolower( str_ireplace( '-', '_', $args['id'] ) );
-			$args['options']['textarea_name'] = $this->get_html_name_attribute();
 		}
 
 		$option_types = apply_filters( 'cmb2_all_or_nothing_types', array( 'select', 'radio', 'radio_inline', 'taxonomy_select', 'taxonomy_radio', 'taxonomy_radio_inline' ), $this );

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -322,7 +322,7 @@ abstract class CMB2_Field_Group {
 						// but that is only called on instantiation of the field object.  Early instantiation is missing
 						// getting these set.
 						$field_object->args[ '_id' ] = $field_object->group->args( 'id' ) . '_' . $field_object->group->index . '_' . $field_object->args['id'];
-						$field_object->args[ '_name' ] = $field_object->group->args( 'id' ) . '[' . $field_object->group->index . '][' . $field_object->args['name'] . ']';
+						$field_object->args[ '_name' ] = $field_object->group->args( 'id' ) . '[' . $field_object->group->index . '][' . $field_object->args['id'] . ']';
 
 						// Todo: Same pattern as the get_field() hack again
 						// With early instantiation we don't need to call get_field() here any more but

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -635,6 +635,10 @@ abstract class CMB2_Field_Group {
 
 			// Also Todo: duplication is getting messier and messier without a field object refactor.  Duct tape only here
 			if( is_array( $field ) && isset( $field[ 'options' ] ) ) {
+				// Here's the rub: we already had a field object tucked away but someone may have gotten an instance,
+				// changed some options, and then passed the arg array-- not the field object-- to something that calls
+				// through to here.  The expected behavior per unit tests is that those changed options persist, so we
+				// make sure to copy them over if they exist.  A better solution is badly needed.
 				$field_object->args[ 'options' ] = $field[ 'options' ];
 			}
 

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -315,6 +315,16 @@ abstract class CMB2_Field_Group {
 
 						$field_object->args[ 'show_names' ] = $field_group->args( 'show_names' );
 						$field_object->args[ 'context' ]    = $field_group->args( 'context' );
+
+						// Todo: Same pattern as the get_field() hack again
+						// With early instantiation we don't need to call get_field() here any more but
+						// we do need to call get_data() in order to copy over this row's data for each
+						// individual field inside the group field.  But in order for get_data() to work
+						// we also need to copy a few other properties to keep them in sync.
+						$field_object->object_id = $this->object_id;
+						$field_object->object_type = $this->object_type;
+						$field_object->escaped_value = null;
+						$field_object->value = $field_object->get_data();
 						$field_object->render_field();
 					}
 				}

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -627,10 +627,17 @@ abstract class CMB2_Field_Group {
 		$index = implode( '', $ids ) . ( $field_group ? $field_group->index : '' );
 		$field_object = $this->get_field_object( $index );
 		if ( ! is_null( $field_object ) ) {
-			// Todo: Hacked this to ensure field objects get updated if data was inserted after instantiation
+
+			// Todo: Hacked this to ensure field objects get updated if data was changed after instantiation
 			$field_object->object_id = $this->object_id;
 			$field_object->object_type = $this->object_type;
 			$field_object->escaped_value = null;
+
+			// Also Todo: duplication is getting messier and messier without a field object refactor.  Duct tape only here
+			if( is_array( $field ) && isset( $field[ 'options' ] ) ) {
+				$field_object->args[ 'options' ] = $field[ 'options' ];
+			}
+
 			$field_object->value = $field_object->get_data();
 		} else {
 			$field_object = new CMB2_Field( $this->get_field_args( $field_id, $field, $sub_field_id, $field_group ) );

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -435,7 +435,7 @@ abstract class CMB2_Field_Group {
 		 *                            Will only include field ids that had values change.
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( "cmb2_save_{$object_type}_fields", $object_id, $this->get_cmb_id(), $this->get_updated(), $this );
+		do_action( "cmb2_save_{$object_type}_fields", $object_id, $this->get_id(), $this->get_updated(), $this );
 
 		/**
 		 * Fires after all fields have been saved.
@@ -451,7 +451,7 @@ abstract class CMB2_Field_Group {
 		 *                            Will only include field ids that had values change.
 		 * @param array  $cmb         This CMB2 object
 		 */
-		do_action( "cmb2_save_{$object_type}_fields_{$this->get_cmb_id()}", $object_id, $this->get_updated(), $this );
+		do_action( "cmb2_save_{$object_type}_fields_{$this->get_id()}", $object_id, $this->get_updated(), $this );
 
 	}
 
@@ -474,7 +474,7 @@ abstract class CMB2_Field_Group {
 		 * @param array $cmb       This CMB2 object
 		 * @param int   $object_id The ID of the current object
 		 */
-		do_action( "cmb2_{$this->object_type()}_process_fields_{$this->get_cmb_id()}", $this, $this->object_id() );
+		do_action( "cmb2_{$this->object_type()}_process_fields_{$this->get_id()}", $this, $this->object_id() );
 
 		// Remove the show_on properties so saving works
 		$this->set_show_on( array() );

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -234,7 +234,7 @@ abstract class CMB2_Field_Group {
 
 		$field->peform_param_callback( 'before_group' );
 
-		echo '<div class="cmb-row cmb-repeat-group-wrap"><div class="cmb-td"><div id="', $field->id(), '_repeat" class="cmb-nested cmb-field-list cmb-repeatable-group', $sortable, $repeat_class, '" style="width:100%;">';
+		echo '<div class="cmb-row cmb-repeat-group-wrap"><div class="cmb-td"><div id="', $field->args( '_id' ), '_repeat" class="cmb-nested cmb-field-list cmb-repeatable-group', $sortable, $repeat_class, '" style="width:100%;">';
 
 		if ( $desc || $label ) {
 			$class = $desc ? ' cmb-group-description' : '';
@@ -259,7 +259,7 @@ abstract class CMB2_Field_Group {
 		}
 
 		if ( $field->args( 'repeatable' ) ) {
-			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button data-selector="', $field->id(), '_repeat" data-grouptitle="', $field->options( 'group_title' ), '" class="cmb-add-group-row button">', $field->options( 'add_button' ), '</button></p></div></div>';
+			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button data-selector="', $field->args( '_id' ), '_repeat" data-grouptitle="', $field->options( 'group_title' ), '" class="cmb-add-group-row button">', $field->options( 'add_button' ), '</button></p></div></div>';
 		}
 
 		echo '</div></div></div>';
@@ -286,7 +286,7 @@ abstract class CMB2_Field_Group {
 		<div class="postbox cmb-row cmb-repeatable-grouping', $closed_class, '" data-iterator="', $field_group->index, '">';
 
 			if ( $field_group->args( 'repeatable' ) ) {
-				echo '<button ', $remove_disabled, 'data-selector="', $field_group->id(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row"></button>';
+				echo '<button ', $remove_disabled, 'data-selector="', $field_group->args( '_id' ), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row"></button>';
 			}
 
 			echo '
@@ -322,7 +322,7 @@ abstract class CMB2_Field_Group {
 					echo '
 					<div class="cmb-row cmb-remove-field-row">
 						<div class="cmb-remove-row">
-							<button ', $remove_disabled, 'data-selector="', $field_group->id(), '_repeat" class="button cmb-remove-group-row alignright">', $field_group->options( 'remove_button' ), '</button>
+							<button ', $remove_disabled, 'data-selector="', $field_group->args( '_id' ), '_repeat" class="button cmb-remove-group-row alignright">', $field_group->options( 'remove_button' ), '</button>
 						</div>
 					</div>
 					';

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -46,6 +46,44 @@ abstract class CMB2_Field_Group {
 	public $data_to_save = array();
 
 	/**
+	 * @return null|string
+	 */
+	public function get_html_name_attribute() {
+
+		$name = null;
+
+		if ( $this->group ) {
+			$parent_path = $this->group->get_html_name_attribute();
+			$index = '[' . $this->group->index . ']';
+			$id = '[' . $this->args( 'id' ) . ']';
+			$name = $parent_path .  $index . $id;
+		} else {
+			$name = $this->args( 'id' );
+		}
+
+		return $name;
+	}
+
+	/**
+	 * @return null|string
+	 */
+	public function get_html_id_attribute() {
+
+		$name = null;
+
+		if ( $this->group ) {
+			$parent_path = $this->group->get_html_id_attribute();
+			$index = '_' . $this->group->index;
+			$id = '_' . $this->args( 'id' );
+			$name = $parent_path .  $index . $id;
+		} else {
+			$name = $this->args( 'id' );
+		}
+
+		return $name;
+	}
+
+	/**
 	 * @return array
 	 */
 	public function get_updated() {
@@ -326,14 +364,6 @@ abstract class CMB2_Field_Group {
 
 						$field_object->args[ 'show_names' ] = $field_group->args( 'show_names' );
 						$field_object->args[ 'context' ]    = $field_group->args( 'context' );
-
-						// Todo: Another puzzle to solve:
-						// To build the name and id attribs for the markup we need to know which row index this is among
-						// multiple records in a repeating group.  This is done in CMB2_Field::_set_field_defaults(),
-						// but that is only called on instantiation of the field object.  Early instantiation is missing
-						// getting these set.
-						$field_object->args[ '_id' ] = $field_object->group->args( 'id' ) . '_' . $field_object->group->index . '_' . $field_object->args['id'];
-						$field_object->args[ '_name' ] = $field_object->group->args( 'id' ) . '[' . $field_object->group->index . '][' . $field_object->args['id'] . ']';
 
 						// Todo: Same pattern as the get_field() hack again
 						// With early instantiation we don't need to call get_field() here any more but

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -371,7 +371,10 @@ abstract class CMB2_Field_Group {
 
 			<div class="inside cmb-td cmb-nested cmb-field-list">';
 				// Loop and render repeatable group fields
+				$row_data = $field_group->value[ $field_group->index ];
 				foreach ( $field_group->get_field_objects() as $field_object ) {
+					$field_object->value = $row_data[ $field_object->id() ];
+
 					if ( 'hidden' == $field_object->args[ 'type' ] ) {
 
 						// Save rendering for after the metabox
@@ -386,9 +389,6 @@ abstract class CMB2_Field_Group {
 							$field_object->args['show_names'] = $this->get_show_names();
 						}
 
-						// Todo: copy over this group's portion of the data.
-						// 'value' shouldn't have to be copied around like this and below for atomic fields
-						$field_object->value = $field_group->value[ $field_group->index ][ $field_object->id() ];
 						$this->render_group( $field_object );
 
 					} else {
@@ -401,10 +401,8 @@ abstract class CMB2_Field_Group {
 						// we do need to call get_data() in order to copy over this row's data for each
 						// individual field inside the group field.  But in order for get_data() to work
 						// we also need to copy a few other properties to keep them in sync.
-						$field_object->object_id = $this->object_id;
-						$field_object->object_type = $this->object_type;
 						$field_object->escaped_value = null;
-						$field_object->value = $field_object->get_data();
+
 						$field_object->render_field();
 					}
 				}

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -283,7 +283,7 @@ abstract class CMB2_Field_Group {
 
 		$field->peform_param_callback( 'before_group' );
 
-		echo '<div class="cmb-row cmb-repeat-group-wrap"><div class="cmb-td"><div id="', $field->args( '_id' ), '_repeat" class="cmb-nested cmb-field-list cmb-repeatable-group', $sortable, $repeat_class, '" style="width:100%;">';
+		echo '<div class="cmb-row cmb-repeat-group-wrap"><div class="cmb-td"><div id="', $field->get_html_id_attribute(), '_repeat" class="cmb-nested cmb-field-list cmb-repeatable-group', $sortable, $repeat_class, '" style="width:100%;">';
 
 		if ( $desc || $label ) {
 			$class = $desc ? ' cmb-group-description' : '';
@@ -308,7 +308,7 @@ abstract class CMB2_Field_Group {
 		}
 
 		if ( $field->args( 'repeatable' ) ) {
-			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button data-selector="', $field->args( '_id' ), '_repeat" data-grouptitle="', $field->options( 'group_title' ), '" class="cmb-add-group-row button">', $field->options( 'add_button' ), '</button></p></div></div>';
+			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button data-selector="', $field->get_html_id_attribute(), '_repeat" data-grouptitle="', $field->options( 'group_title' ), '" class="cmb-add-group-row button">', $field->options( 'add_button' ), '</button></p></div></div>';
 		}
 
 		echo '</div></div></div>';
@@ -335,7 +335,7 @@ abstract class CMB2_Field_Group {
 		<div class="postbox cmb-row cmb-repeatable-grouping', $closed_class, '" data-iterator="', $field_group->index, '">';
 
 			if ( $field_group->args( 'repeatable' ) ) {
-				echo '<button ', $remove_disabled, 'data-selector="', $field_group->args( '_id' ), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row"></button>';
+				echo '<button ', $remove_disabled, 'data-selector="', $field_group->get_html_id_attribute(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row"></button>';
 			}
 
 			echo '
@@ -381,7 +381,7 @@ abstract class CMB2_Field_Group {
 					echo '
 					<div class="cmb-row cmb-remove-field-row">
 						<div class="cmb-remove-row">
-							<button ', $remove_disabled, 'data-selector="', $field_group->args( '_id' ), '_repeat" class="button cmb-remove-group-row alignright">', $field_group->options( 'remove_button' ), '</button>
+							<button ', $remove_disabled, 'data-selector="', $field_group->get_html_id_attribute(), '_repeat" class="button cmb-remove-group-row alignright">', $field_group->options( 'remove_button' ), '</button>
 						</div>
 					</div>
 					';

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -385,6 +385,10 @@ abstract class CMB2_Field_Group {
 						if ( ! isset( $field_object->args['show_names'] ) ) {
 							$field_object->args['show_names'] = $this->get_show_names();
 						}
+
+						// Todo: copy over this group's portion of the data.
+						// 'value' shouldn't have to be copied around like this and below for atomic fields
+						$field_object->value = $field_group->value[ $field_group->index ][ $field_object->id() ];
 						$this->render_group( $field_object );
 
 					} else {

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -55,10 +55,10 @@ abstract class CMB2_Field_Group {
 		if ( $this->group ) {
 			$parent_path = $this->group->get_html_name_attribute();
 			$index = '[' . $this->group->index . ']';
-			$id = '[' . $this->args( 'id' ) . ']';
+			$id = '[' . $this->id() . ']';
 			$name = $parent_path .  $index . $id;
 		} else {
-			$name = $this->args( 'id' );
+			$name = $this->id();
 		}
 
 		return $name;
@@ -74,10 +74,10 @@ abstract class CMB2_Field_Group {
 		if ( $this->group ) {
 			$parent_path = $this->group->get_html_id_attribute();
 			$index = '_' . $this->group->index;
-			$id = '_' . $this->args( 'id' );
+			$id = '_' . $this->id();
 			$name = $parent_path .  $index . $id;
 		} else {
-			$name = $this->args( 'id' );
+			$name = $this->id();
 		}
 
 		return $name;
@@ -162,7 +162,7 @@ abstract class CMB2_Field_Group {
 			$fields_array[ $key ] = $field_object->args();
 			$nested_fields = array();
 			foreach ( $field_object->args( 'fields' ) as $this_field ) {
-				$nested_fields[ $this_field[ 'id'] ] = $this_field;
+				$nested_fields[ $this_field[ 'id' ] ] = $this_field;
 			}
 			$fields_array[ $key ] = array_merge( $fields_array[ $key ], array( 'fields' => $nested_fields) );
 		}
@@ -604,7 +604,7 @@ abstract class CMB2_Field_Group {
 		$field_group->index = 0;
 
 		foreach ( array_values( $field_group->get_field_objects() ) as $field_object ) {
-			$sub_id = $field_object->args( 'id' );
+			$sub_id = $field_object->id();
 
 			foreach ( (array) $group_vals as $field_group->index => $post_vals ) {
 
@@ -765,7 +765,7 @@ abstract class CMB2_Field_Group {
 		$parent_field_id = '';
 		$field_group = null;
 		if ( is_a( $this, 'CMB2_Field' ) && 'group' == $this->args( 'type' ) ) {
-			$parent_field_id = $this->args( 'id' );
+			$parent_field_id = $this->id();
 
 			$new_field = new CMB2_Field( array(
 				'field_args'  => $field,

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -133,6 +133,22 @@ abstract class CMB2_Field_Group {
 	}
 
 	/**
+	 * Add a hidden field to the list of hidden fields to be rendered later
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $args Array of arguments to be passed to CMB2_Field
+	 *
+	 * @return CMB2_Types The newly created types object
+	 */
+	public function add_hidden_field( $args ) {
+
+		$types_object = new CMB2_Types( new CMB2_Field( $args ) );
+		$this->hidden_fields[] = $types_object;
+		return $types_object;
+	}
+
+	/**
 	 * @return array
 	 */
 	public function get_data_to_save() {
@@ -403,18 +419,6 @@ abstract class CMB2_Field_Group {
 		';
 
 		$field_group->peform_param_callback( 'after_group_row' );
-	}
-
-	/**
-	 * Add a hidden field to the list of hidden fields to be rendered later
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param array $args Array of arguments to be passed to CMB2_Field
-	 */
-	public function add_hidden_field( $args ) {
-
-		$this->get_hidden_fields()[] = new CMB2_Types( new CMB2_Field( $args ) );
 	}
 
 	/**

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -316,6 +316,14 @@ abstract class CMB2_Field_Group {
 						$field_object->args[ 'show_names' ] = $field_group->args( 'show_names' );
 						$field_object->args[ 'context' ]    = $field_group->args( 'context' );
 
+						// Todo: Another puzzle to solve:
+						// To build the name and id attribs for the markup we need to know which row index this is among
+						// multiple records in a repeating group.  This is done in CMB2_Field::_set_field_defaults(),
+						// but that is only called on instantiation of the field object.  Early instantiation is missing
+						// getting these set.
+						$field_object->args[ '_id' ] = $field_object->group->args( 'id' ) . '_' . $field_object->group->index . '_' . $field_object->args['id'];
+						$field_object->args[ '_name' ] = $field_object->group->args( 'id' ) . '[' . $field_object->group->index . '][' . $field_object->args['name'] . ']';
+
 						// Todo: Same pattern as the get_field() hack again
 						// With early instantiation we don't need to call get_field() here any more but
 						// we do need to call get_data() in order to copy over this row's data for each

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -103,6 +103,17 @@ abstract class CMB2_Field_Group {
 	}
 
 	/**
+	 * @param $field
+	 *
+	 * @return mixed
+	 */
+	public function add_updated( $field ) {
+
+		$this->updated[] = $field;
+		return $field;
+	}
+
+	/**
 	 * @return CMB2_Types[]
 	 */
 	public function get_hidden_fields() {
@@ -575,7 +586,7 @@ abstract class CMB2_Field_Group {
 				) );
 
 				if ( $field->save_field_from_data( $this->get_data_to_save() ) ) {
-					$this->get_updated()[] = $field->id();
+					$this->add_updated( $field->id() );
 				}
 
 				break;
@@ -632,7 +643,7 @@ abstract class CMB2_Field_Group {
 				$is_removed = ( empty( $new_val ) && ! empty( $old_val ) );
 				// Compare values and add to `$updated` array
 				if ( $is_updated || $is_removed ) {
-					$this->get_updated()[] = $base_id . '::' . $field_group->index . '::' . $sub_id;
+					$this->add_updated( $base_id . '::' . $field_group->index . '::' . $sub_id );
 				}
 
 				// Add to `$saved` array

--- a/includes/CMB2_Field_Group.php
+++ b/includes/CMB2_Field_Group.php
@@ -396,11 +396,7 @@ abstract class CMB2_Field_Group {
 						$field_object->args[ 'show_names' ] = $field_group->args( 'show_names' );
 						$field_object->args[ 'context' ]    = $field_group->args( 'context' );
 
-						// Todo: Same pattern as the get_field() hack again
-						// With early instantiation we don't need to call get_field() here any more but
-						// we do need to call get_data() in order to copy over this row's data for each
-						// individual field inside the group field.  But in order for get_data() to work
-						// we also need to copy a few other properties to keep them in sync.
+						// Todo: escaped_value could be caching old data, revisit
 						$field_object->escaped_value = null;
 
 						$field_object->render_field();

--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -308,17 +308,14 @@ class CMB2_Sanitize {
 	}
 
 	/**
-	 * Todo [PGL] This needs looked over on the _id and _name references
-	 *
-	 * Peforms saving of `file` attachement's ID
+	 * Performs saving of `file` attachment's ID
 	 * @since  1.1.0
 	 */
 	public function _save_file_id() {
 		$group      = $this->field->group;
 		$args       = $this->field->args();
-		$args['id'] = $args['_id'] . '_id';
+		$args[ 'id' ] = $args[ 'id' ] . '_id';
 
-		unset( $args['_id'], $args['_name'] );
 		// And get new field object
 		$field      = new CMB2_Field( array(
 			'field_args'  => $args,
@@ -326,13 +323,13 @@ class CMB2_Sanitize {
 			'object_id'   => $this->field->object_id,
 			'object_type' => $this->field->object_type,
 		) );
-		$id_key     = $field->_id();
+		$id_key     = $field->id();
 		$id_val_old = $field->escaped_value( 'absint' );
 
 		if ( $group ) {
 			// Check group $_POST data
 			$i       = $group->index;
-			$base_id = $group->_id();
+			$base_id = $group->id();
 			$id_val  = isset( $_POST[ $base_id ][ $i ][ $id_key ] ) ? absint( $_POST[ $base_id ][ $i ][ $id_key ] ) : 0;
 
 		} else {

--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -308,6 +308,8 @@ class CMB2_Sanitize {
 	}
 
 	/**
+	 * Todo [PGL] This needs looked over on the _id and _name references
+	 *
 	 * Peforms saving of `file` attachement's ID
 	 * @since  1.1.0
 	 */

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -932,7 +932,7 @@ class CMB2_Types {
 		// Reset field args for attachment ID
 		$args = $this->field->args();
 		// If we're looking at a file in a group, we need to get the non-prefixed id
-		$args['id'] = ( $this->field->group ? $this->field->args( '_id' ) : $cached_id ) . '_id';
+		$args['id'] = ( $this->field->group ? $this->field->args( 'id' ) : $cached_id ) . '_id';
 		unset( $args['_id'], $args['_name'] );
 
 		// And get new field object

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -284,7 +284,7 @@ class CMB2_Types {
 	 * @since  1.0.0
 	 */
 	public function render_repeatable_field() {
-		$table_id = $this->field->id() . '_repeat';
+		$table_id = $this->field->args( '_id' ) . '_repeat';
 
 		$this->_desc( true, true, true );
 		?>
@@ -406,7 +406,7 @@ class CMB2_Types {
 	 * @return string          Id attribute
 	 */
 	public function _id( $suffix = '' ) {
-		return $this->field->id() . $suffix . ( $this->field->args( 'repeatable' ) ? '_' . $this->iterator . '" data-iterator="' . $this->iterator : '' );
+		return $this->field->args( '_id' ) . $suffix . ( $this->field->args( 'repeatable' ) ? '_' . $this->iterator . '" data-iterator="' . $this->iterator : '' );
 	}
 
 	/**

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -937,7 +937,7 @@ class CMB2_Types {
 		// Reset field args for attachment ID
 		$args = $this->field->args();
 		// If we're looking at a file in a group, we need to get the non-prefixed id
-		$args['id'] = ( $this->field->group ? $this->field->args( 'id' ) : $cached_id ) . '_id';
+		$args['id'] = ( $this->field->group ? $this->field->id() : $cached_id ) . '_id';
 
 		// And get new field object
 		$this->field = new CMB2_Field( array(

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -284,7 +284,7 @@ class CMB2_Types {
 	 * @since  1.0.0
 	 */
 	public function render_repeatable_field() {
-		$table_id = $this->field->args( '_id' ) . '_repeat';
+		$table_id = $this->field->get_html_id_attribute() . '_repeat';
 
 		$this->_desc( true, true, true );
 		?>
@@ -396,7 +396,7 @@ class CMB2_Types {
 	 * @return string          Name attribute
 	 */
 	public function _name( $suffix = '' ) {
-		return $this->field->args( '_name' ) . ( $this->field->args( 'repeatable' ) ? '[' . $this->iterator . ']' : '' ) . $suffix;
+		return $this->field->get_html_name_attribute() . ( $this->field->args( 'repeatable' ) ? '[' . $this->iterator . ']' : '' ) . $suffix;
 	}
 
 	/**
@@ -406,7 +406,7 @@ class CMB2_Types {
 	 * @return string          Id attribute
 	 */
 	public function _id( $suffix = '' ) {
-		return $this->field->args( '_id' ) . $suffix . ( $this->field->args( 'repeatable' ) ? '_' . $this->iterator . '" data-iterator="' . $this->iterator : '' );
+		return $this->field->get_html_id_attribute() . $suffix . ( $this->field->args( 'repeatable' ) ? '_' . $this->iterator . '" data-iterator="' . $this->iterator : '' );
 	}
 
 	/**
@@ -488,12 +488,17 @@ class CMB2_Types {
 	}
 
 	public function wysiwyg( $args = array() ) {
+
 		$a = $this->parse_args( $args, 'input', array(
 			'id'      => $this->_id(),
 			'value'   => $this->field->escaped_value( 'stripslashes' ),
 			'desc'    => $this->_desc( true ),
 			'options' => $this->field->options(),
 		) );
+
+		// Todo: This needs to be updated dynamically but only for wysiwyg fields
+		// Better solution?
+		$a[ 'options' ][ 'textarea_name' ] = $this->_name();
 
 		wp_editor( $a['value'], $a['id'], $a['options'] );
 		echo $a['desc'];
@@ -933,7 +938,6 @@ class CMB2_Types {
 		$args = $this->field->args();
 		// If we're looking at a file in a group, we need to get the non-prefixed id
 		$args['id'] = ( $this->field->group ? $this->field->args( 'id' ) : $cached_id ) . '_id';
-		unset( $args['_id'], $args['_name'] );
 
 		// And get new field object
 		$this->field = new CMB2_Field( array(

--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -203,10 +203,10 @@ class CMB2_hookup {
 			if ( $this->cmb->get_title() ) {
 
 				if ( $this->cmb->get_closed() ) {
-					add_filter( "postbox_classes_{$post_type}_{$this->cmb->get_cmb_id()}", array( $this, 'close_metabox_class' ) );
+					add_filter( "postbox_classes_{$post_type}_{$this->cmb->get_id()}", array( $this, 'close_metabox_class' ) );
 				}
 
-				add_meta_box( $this->cmb->get_cmb_id(), $this->cmb->get_title(), array( $this, 'metabox_callback' ), $post_type, $this->cmb->get_context(), $this->cmb->get_priority() );
+				add_meta_box( $this->cmb->get_id(), $this->cmb->get_title(), array( $this, 'metabox_callback' ), $post_type, $this->cmb->get_context(), $this->cmb->get_priority() );
 			}
 		}
 	}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -282,7 +282,7 @@ function cmb2_print_metabox_form( $meta_box, $object_id = 0, $args = array() ) {
 	$format_parts = explode( '%3$s', $form_format );
 
 	// Show cmb form
-	printf( $format_parts[0], $cmb->get_cmb_id(), $object_id );
+	printf( $format_parts[0], $cmb->get_id(), $object_id );
 	$cmb->show_form();
 
 	if ( isset( $format_parts[1] ) && $format_parts[1] ) {

--- a/tests/test-cmb-core.php
+++ b/tests/test-cmb-core.php
@@ -105,7 +105,7 @@ class Test_CMB2_Core extends Test_CMB2 {
 			'bg_color' => '#ffffff',
 			'my_name' => 'Justin',
 		);
-		add_option( $this->options_cmb->cmb_id, $this->opt_set );
+		add_option( $this->options_cmb->get_id(), $this->opt_set );
 
 		$this->post_id = $this->factory->post->create();
 
@@ -148,7 +148,7 @@ class Test_CMB2_Core extends Test_CMB2 {
 
 	public function test_id_get() {
 		$cmb = new CMB2( array( 'id' => $this->cmb_id ) );
-		$this->assertEquals( $cmb->cmb_id, $this->cmb_id );
+		$this->assertEquals( $cmb->get_id(), $this->cmb_id );
 	}
 
 	public function test_defaults_set() {
@@ -740,7 +740,7 @@ class Test_CMB2_Core extends Test_CMB2 {
 
 		$cmb = cmb2_get_metabox( 'test' );
 
-		$this->assertEquals( 'test', $cmb->cmb_id );
+		$this->assertEquals( 'test', $cmb->get_id() );
 		$this->assertEquals( array(), $cmb->updated );
 		$this->assertEquals( 0, $cmb->object_id );
 	}

--- a/tests/test-cmb-field.php
+++ b/tests/test-cmb-field.php
@@ -91,13 +91,13 @@ class Test_CMB2_Field extends Test_CMB2 {
 	public function test_cmb2_row_classes_field_callback_with_array() {
 		// Add row classes dynamically with a callback that returns an array
 		$classes = $this->field->row_classes();
-		$this->assertEquals( 'cmb-type-text cmb2-id-test-test table-layout type name desc before after options_cb options attributes protocols default select_all_button multiple repeatable inline on_front show_names date_format time_format description preview_size render_row_cb label_cb id before_field after_field row_classes _id _name', $classes );
+		$this->assertEquals( 'cmb-type-text cmb2-id-test-test table-layout type name desc before after options_cb options attributes protocols default select_all_button multiple repeatable inline on_front show_names date_format time_format description preview_size render_row_cb label_cb id before_field after_field row_classes', $classes );
 	}
 
 	public function test_cmb2_default_field_callback_with_array() {
 		// Add row classes dynamically with a callback that returns an array
 		$default = $this->field->args( 'default' );
-		$this->assertEquals( 'type, name, desc, before, after, options_cb, options, attributes, protocols, default, select_all_button, multiple, repeatable, inline, on_front, show_names, date_format, time_format, description, preview_size, render_row_cb, label_cb, id, before_field, after_field, row_classes, _id, _name', $default );
+		$this->assertEquals( 'type, name, desc, before, after, options_cb, options, attributes, protocols, default, select_all_button, multiple, repeatable, inline, on_front, show_names, date_format, time_format, description, preview_size, render_row_cb, label_cb, id, before_field, after_field, row_classes', $default );
 	}
 
 	public function test_cmb2_row_classes_field_callback_with_string() {


### PR DESCRIPTION
So @wpscholar can do PRs against CMB2/nested-fields-trunk directly.
