### PR TITLE
[#326] Included the usage of the before_field for the default currency

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1131,6 +1131,10 @@ class CMB2_Field extends CMB2_Base {
 			$args['options']['textarea_name'] = $args['_name'];
 		}
 
+		if( 'text_money' === $args['type'] ) {
+ 			$args['before_field'] = apply_filters( 'cmb2_text_money_before_field_filter', ( isset($args['before_field']) ? $args['before_field'] : '$' ), $this );
+ 		}
+
 		$option_types = apply_filters( 'cmb2_all_or_nothing_types', array( 'select', 'radio', 'radio_inline', 'taxonomy_select', 'taxonomy_radio', 'taxonomy_radio_inline' ), $this );
 
 		if ( in_array( $args['type'], $option_types, true ) ) {

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -433,7 +433,7 @@ class CMB2_Types {
 			'class' => 'cmb2-text-money',
 			'desc' => $this->_desc(),
 		) );
-		return ( ! $this->field->get_param_callback_result( 'before_field' ) ? '$ ' : ' ' ) . $input;
+		return ( ! $this->field->get_param_callback_result( 'before_field' ) ? '' : ' ' ) . $input;
 	}
 
 	public function textarea_small() {


### PR DESCRIPTION
Fixes #326 .
### Changes proposed in this pull request
-  Possibility of defining a currency symbol for the `text_money` field type.

Ping @jtsternberg 
