### PR TITLE
Taxonomy select heirarchy

### DIFF
--- a/includes/types/CMB2_Type_Multi_Base.php
+++ b/includes/types/CMB2_Type_Multi_Base.php
@@ -13,6 +13,17 @@
 abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 
 	/**
+	 * Generates html for an optgroup element
+	 * @param  array $args Arguments array containing: label (label for the option group), and options (html for the options elements)
+	 * @return string Generated optgroup element html
+	 */
+	public function select_option( $args = array() ) {
+		return sprintf( "\t" . '<optgroup label="%s">' . "\n", $label) . 
+			$options .
+			sprintf( "\n\t</optgroup>\n" );
+	}
+	
+	/**
 	 * Generates html for an option element
 	 * @since  1.1.0
 	 * @param  array  $args Arguments array containing value, label, and checked boolean

--- a/includes/types/CMB2_Type_Multi_Base.php
+++ b/includes/types/CMB2_Type_Multi_Base.php
@@ -17,9 +17,9 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 	 * @param  array $args Arguments array containing: label (label for the option group), and options (html for the options elements)
 	 * @return string Generated optgroup element html
 	 */
-	public function select_option( $args = array() ) {
-		return sprintf( "\t" . '<optgroup label="%s">' . "\n", $label) . 
-			$options .
+	public function select_optgroup( $args = array() ) {
+		return sprintf( "\t" . '<optgroup label="%s">' . "\n", $args['label']) . 
+			$args['options'] .
 			sprintf( "\n\t</optgroup>\n" );
 	}
 	

--- a/includes/types/CMB2_Type_Taxonomy_Select.php
+++ b/includes/types/CMB2_Type_Taxonomy_Select.php
@@ -65,7 +65,7 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 		}
 		
 		if ( ! empty( $terms ) ) {
-			if ( $hierarchy ) {
+			if ( $hierarchy == true ) {
 				$groups = array();
 				foreach ( $terms as $term ) {
 					if ( $term->parent == 0 ) {
@@ -88,7 +88,7 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 					) );
 				}
 			} else {
-				$this->render_options( $terms, $saved_term );
+				$options .= $this->render_options( $terms, $saved_term );
 			}
 		}
 

--- a/includes/types/CMB2_Type_Taxonomy_Select.php
+++ b/includes/types/CMB2_Type_Taxonomy_Select.php
@@ -31,7 +31,6 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 		$terms       = $this->get_terms();
 		$options     = '';
 		$option_none = $this->field->args( 'show_option_none' );
-		echo "<pre>"; var_dump($this->field->args); die;
 		$heirarchy   = $this->field->args( 'heirarchy' );
 		
 		if ( ! empty( $option_none ) ) {
@@ -70,23 +69,29 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 				$groups = array();
 				foreach ( $terms as $term ) {
 					if ( $term->parent == 0 ) {
-						$groups[$term->term_id] = array( 'term' => $term, 'children' => array() );
-					} 
-					if ( !isset( $groups[$term->parent] ) ) {
-						$groups[$term->parent] = array('term' => null, 'children' => array() );
+						if ( isset( $groups[$term->term_id] ) ) {
+							$groups[$term->term_id]['term'] = $term;
+						} else {
+							$groups[$term->term_id] = array( 'term' => $term, 'children' => array() );
+						}
+					} else {
+						if ( !isset( $groups[$term->parent] ) ) {
+							$groups[$term->parent] = array('term' => null, 'children' => array() );
+						}
+						$groups[$term->parent]['children'][] = $term;
 					}
-					$groups[$term->parent]['children'][] = $term; 
 				}
 				foreach( $groups as $group ) {
-					$options .= $this->select_group( array (
+					$options .= $this->select_optgroup( array (
 							'label' => $group['term']->name,
 							'options' => $this->render_options( $group['children'], $saved_term )
-					));
+					) );
 				}
 			} else {
 				$this->render_options( $terms, $saved_term );
 			}
 		}
+		echo $options;
 
 		return $this->rendered(
 			$this->types->select( array( 'options' => $options ) )

--- a/includes/types/CMB2_Type_Taxonomy_Select.php
+++ b/includes/types/CMB2_Type_Taxonomy_Select.php
@@ -12,6 +12,18 @@
  */
 class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 
+	private function render_options( $terms , $saved_term ) {
+		$options = '';
+		foreach ( $terms as $term ) {
+			$options .= $this->select_option( array(
+					'label'   => $term->name,
+					'value'   => $term->slug,
+					'checked' => $saved_term === $term->slug,
+			) );
+		}
+		return $options;
+	}
+	
 	public function render() {
 		$names = $this->get_object_terms();
 
@@ -19,7 +31,9 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 		$terms       = $this->get_terms();
 		$options     = '';
 		$option_none = $this->field->args( 'show_option_none' );
-
+		echo "<pre>"; var_dump($this->field->args); die;
+		$heirarchy   = $this->field->args( 'heirarchy' );
+		
 		if ( ! empty( $option_none ) ) {
 
 			$field_id = $this->_id();
@@ -50,14 +64,27 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 				'checked' => $saved_term == $option_none_value,
 			) );
 		}
-
+		
 		if ( ! empty( $terms ) ) {
-			foreach ( $terms as $term ) {
-				$options .= $this->select_option( array(
-					'label'   => $term->name,
-					'value'   => $term->slug,
-					'checked' => $saved_term === $term->slug,
-				) );
+			if ( $heirarchy ) {
+				$groups = array();
+				foreach ( $terms as $term ) {
+					if ( $term->parent == 0 ) {
+						$groups[$term->term_id] = array( 'term' => $term, 'children' => array() );
+					} 
+					if ( !isset( $groups[$term->parent] ) ) {
+						$groups[$term->parent] = array('term' => null, 'children' => array() );
+					}
+					$groups[$term->parent]['children'][] = $term; 
+				}
+				foreach( $groups as $group ) {
+					$options .= $this->select_group( array (
+							'label' => $group['term']->name,
+							'options' => $this->render_options( $group['children'], $saved_term )
+					));
+				}
+			} else {
+				$this->render_options( $terms, $saved_term );
 			}
 		}
 

--- a/includes/types/CMB2_Type_Taxonomy_Select.php
+++ b/includes/types/CMB2_Type_Taxonomy_Select.php
@@ -91,7 +91,6 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 				$this->render_options( $terms, $saved_term );
 			}
 		}
-		echo $options;
 
 		return $this->rendered(
 			$this->types->select( array( 'options' => $options ) )

--- a/includes/types/CMB2_Type_Taxonomy_Select.php
+++ b/includes/types/CMB2_Type_Taxonomy_Select.php
@@ -31,7 +31,7 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 		$terms       = $this->get_terms();
 		$options     = '';
 		$option_none = $this->field->args( 'show_option_none' );
-		$heirarchy   = $this->field->args( 'heirarchy' );
+		$hierarchy   = $this->field->args( 'hierarchy' );
 		
 		if ( ! empty( $option_none ) ) {
 
@@ -65,7 +65,7 @@ class CMB2_Type_Taxonomy_Select extends CMB2_Type_Taxonomy_Base {
 		}
 		
 		if ( ! empty( $terms ) ) {
-			if ( $heirarchy ) {
+			if ( $hierarchy ) {
 				$groups = array();
 				foreach ( $terms as $term ) {
 					if ( $term->parent == 0 ) {

--- a/tests/test-cmb-types-base.php
+++ b/tests/test-cmb-types-base.php
@@ -112,7 +112,7 @@ abstract class Test_CMB2_Types_Base extends Test_CMB2 {
 
 		$this->post_id = $this->factory->post->create();
 		$this->term = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'test_category' ) );
-		$this->term2 = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'number_2' ) );
+		$this->term2 = $this->factory->term->create( array( 'taxonomy' => 'category', 'name' => 'number_2' , 'parent' => 1 ) );
 
 		wp_set_object_terms( $this->post_id, 'test_category', 'category' );
 

--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -531,6 +531,20 @@ class Test_CMB2_Types extends Test_CMB2_Types_Base {
 		);
 	}
 
+	public function test_taxonomy_select_field_hierarchy() {
+	
+		$args = $this->options_test['fields'][0];
+		$args['type'] = 'taxonomy_select';
+		$args['taxonomy'] = 'category';
+		$args['hierarchy'] = true;
+		$field = $this->get_field_object( $args );
+	
+		$this->assertHTMLstringsAreEqual(
+				'<select class="cmb2_select" name="options_test_field" id="options_test_field"><option value="" >None</option><optgroup label="test_category"><option value="number_2" >number_2</option></optgroup></select><p class="cmb2-metabox-description">This is a description</p>',
+				$this->capture_render( array( $this->get_field_type_object( $field ), 'render' ) )
+				);
+	}
+	
 	public function test_radio_field() {
 		$args = $this->options_test['fields'][0];
 		$args['type'] = 'radio';

--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -540,7 +540,7 @@ class Test_CMB2_Types extends Test_CMB2_Types_Base {
 		$field = $this->get_field_object( $args );
 	
 		$this->assertHTMLstringsAreEqual(
-				'<select class="cmb2_select" name="options_test_field" id="options_test_field"><option value="" >None</option><optgroup label="test_category"><option value="number_2" >number_2</option></optgroup></select><p class="cmb2-metabox-description">This is a description</p>',
+				'<select class="cmb2_select" name="options_test_field" id="options_test_field"><option value="" >None</option><optgroup label="Uncategorized"><option value="number_2" >number_2</option></optgroup><optgroup label="test_category"></optgroup></select><p class="cmb2-metabox-description">This is a description</p>',
 				$this->capture_render( array( $this->get_field_type_object( $field ), 'render' ) )
 				);
 	}


### PR DESCRIPTION
Fixes #751 .
### Changes proposed in this pull request
-  Adds hierarchy (boolean) option to taxonomy_select field
-  When hierarchy is true, it groups the taxonomy terms by parent and produces the following for each parent term.

```
<optgroup label="Parent Term">
    <option value="{term_id}" {checked}>Term name</option>
    <option value="{term_id}" {checked}>Term name</option>
</optgroup>
```
