### PR TITLE
WPCS VIP sniffs -- includes/CMB2.php

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -492,7 +492,7 @@ class CMB2 extends CMB2_Base {
 		$closed_class = $field_group->options( 'closed' ) ? ' closed' : '';
 
 		echo '
-		<div class="postbox cmb-row cmb-repeatable-grouping', $closed_class, '" data-iterator="', $field_group->index, '">';
+		<div class="postbox cmb-row cmb-repeatable-grouping', wp_kses( $closed_class, array() ), '" data-iterator="', absint( $field_group->index ), '">';
 
 		if ( $field_group->args( 'repeatable' ) ) {
 			echo '<button type="button" ', $remove_disabled, 'data-selector="', $field_group->id(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -888,7 +888,7 @@ class CMB2 extends CMB2_Base {
 		// Try to get our object ID from the global space.
 		switch ( $this->object_type() ) {
 			case 'user':
-				$object_id = isset( $_REQUEST['user_id'] ) ? wp_unslash( absint( $_REQUEST['user_id'] ) ) : $object_id;
+				$object_id = ( wp_verify_nonce( $this->nonce() ) && isset( $_REQUEST['user_id'] ) ) ? wp_unslash( absint( $_REQUEST['user_id'] ) ) : $object_id;
 				$object_id = ! $object_id && 'user-new.php' !== $pagenow && isset( $GLOBALS['user_ID'] ) ? $GLOBALS['user_ID'] : $object_id;
 				break;
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1450,6 +1450,13 @@ class CMB2 extends CMB2_Base {
 		return $this->prop( 'context' ) && in_array( $this->prop( 'context' ), array( 'form_top', 'before_permalink', 'after_title', 'after_editor' ), true );
 	}
 
+	public function kses_group_wrap_atts() {
+		return array(
+			'class' => array(),
+			'style' => array(),
+		);
+	}
+
 	/**
 	 * Magic getter for our object.
 	 *

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -889,7 +889,7 @@ class CMB2 extends CMB2_Base {
 		// Try to get our object ID from the global space.
 		switch ( $this->object_type() ) {
 			case 'user':
-				$object_id = isset( $_REQUEST['user_id'] ) ? wp_unslash( $_REQUEST['user_id'] ) : $object_id;
+				$object_id = isset( $_REQUEST['user_id'] ) ? wp_unslash( absint( $_REQUEST['user_id'] ) ) : $object_id;
 				$object_id = ! $object_id && 'user-new.php' !== $pagenow && isset( $GLOBALS['user_ID'] ) ? $GLOBALS['user_ID'] : $object_id;
 				break;
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -436,7 +436,7 @@ class CMB2 extends CMB2_Base {
 		}
 
 		if ( $field_group->args( 'repeatable' ) ) {
-			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button type="button" data-selector="', esc_attr( $field_group->id() ), '_repeat" data-grouptitle="', esc_attr( $field_group->options( 'group_title' ) ), '" class="cmb-add-group-row button-secondary">', $field_group->options( 'add_button' ), '</button></p></div></div>';
+			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button type="button" data-selector="', esc_attr( $field_group->id() ), '_repeat" data-grouptitle="', esc_attr( $field_group->options( 'group_title' ) ), '" class="cmb-add-group-row button-secondary">', esc_html( $field_group->options( 'add_button' ) ), '</button></p></div></div>';
 		}
 
 		echo '</div></div></div>';

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -87,14 +87,14 @@ class CMB2 extends CMB2_Base {
  		 * and handles hooking in and saving those fields.
 		 */
 		'hookup'           => true,
-		'save_fields'      => true, // Will not save during hookup if false.
+		'save_fields'      => true,  // Will not save during hookup if false.
 		'closed'           => false, // Default metabox to being closed.
 		'taxonomies'       => array(),
 		'new_user_section' => 'add-new-user', // or 'add-existing-user'.
 		'new_term_section' => true,
 		'show_in_rest'     => false,
-		'classes'          => null, // Optionally add classes to the CMB2 wrapper
-		'classes_cb'       => '', // Optionally add classes to the CMB2 wrapper (via a callback)
+		'classes'          => null,  // Optionally add classes to the CMB2 wrapper
+		'classes_cb'       => '',    // Optionally add classes to the CMB2 wrapper (via a callback).
 	);
 
 	/**

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1450,11 +1450,24 @@ class CMB2 extends CMB2_Base {
 		return $this->prop( 'context' ) && in_array( $this->prop( 'context' ), array( 'form_top', 'before_permalink', 'after_title', 'after_editor' ), true );
 	}
 
-	public function kses_group_wrap_atts() {
-		return array(
-			'class' => array(),
-			'style' => array(),
-		);
+	public function kses_args( $type ) {
+		$params = array();
+
+		switch ( $type ) {
+			case 'group_wrap_attributes' :
+				$params = array(
+					'class' => array(),
+					'style' => array(),
+				);
+				break;
+			case 'remove_disabled' :
+				$params = array(
+					'disabled' => array(),
+				);
+		}
+
+
+		return $params;
 	}
 
 	/**

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1297,7 +1297,9 @@ class CMB2 extends CMB2_Base {
 	 */
 	protected function _add_field_to_array( $field, &$fields, $position = 0 ) {
 		if ( $position ) {
-			CMB2_Utils::array_insert( $fields, array( $field['id'] => $field ), $position );
+			CMB2_Utils::array_insert( $fields, array(
+				$field['id'] => $field,
+			), $position );
 		} else {
 			$fields[ $field['id'] ] = $field;
 		}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -621,16 +621,8 @@ class CMB2 extends CMB2_Base {
 	 */
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save = array() ) {
 
-		if ( $data_to_save ) {
-			// If data was passed.
-			$this->data_to_save = $data_to_save;
-		} elseif ( wp_verify_nonce( $this->nonce ) ) {
-			// Fall-back to $_POST data if no data was passed.
-			$this->data_to_save = $_POST;
-		} else {
-			// If we failed the nonce check, don't save anything.
-			$this->data_to_save = array();
-		}
+		// Fall-back to $_POST data if no data was passed.
+		$data_to_save = ! empty( $data_to_save ) ? $data_to_save : $_POST;
 
 		$object_id = $this->object_id( $object_id );
 		$object_type = $this->object_type( $object_type );
@@ -888,7 +880,7 @@ class CMB2 extends CMB2_Base {
 		// Try to get our object ID from the global space.
 		switch ( $this->object_type() ) {
 			case 'user':
-				$object_id = ( wp_verify_nonce( $this->nonce() ) && isset( $_REQUEST['user_id'] ) ) ? wp_unslash( absint( $_REQUEST['user_id'] ) ) : $object_id;
+				$object_id = isset( $_REQUEST['user_id'] ) ? wp_unslash( absint( $_REQUEST['user_id'] ) ) : $object_id;
 				$object_id = ! $object_id && 'user-new.php' !== $pagenow && isset( $GLOBALS['user_ID'] ) ? $GLOBALS['user_ID'] : $object_id;
 				break;
 
@@ -1025,7 +1017,7 @@ class CMB2 extends CMB2_Base {
 			$type = 'term';
 		}
 
-		if ( defined( 'DOING_AJAX' ) && wp_verify_nonce( $this->nonce ) && isset( $_POST['action'] ) && 'add-tag' === $_POST['action'] ) {
+		if ( defined( 'DOING_AJAX' ) && isset( $_POST['action'] ) && 'add-tag' === $_POST['action'] ) {
 			$type = 'term';
 		}
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -495,7 +495,7 @@ class CMB2 extends CMB2_Base {
 		<div class="postbox cmb-row cmb-repeatable-grouping', wp_kses( $closed_class, array() ), '" data-iterator="', absint( $field_group->index ), '">';
 
 		if ( $field_group->args( 'repeatable' ) ) {
-			echo '<button type="button" ', wp_kses( $remove_disabled, $this->kses_args( 'remove_disabled' ) ), 'data-selector="', $field_group->id(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
+			echo '<button type="button" ', wp_kses( $remove_disabled, $this->kses_args( 'remove_disabled' ) ), 'data-selector="', esc_attr( $field_group->id() ), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
 		}
 
 			echo '

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -500,7 +500,7 @@ class CMB2 extends CMB2_Base {
 
 			echo '
 			<div class="cmbhandle" title="' , esc_attr__( 'Click to toggle', 'cmb2' ), '"><br></div>
-			<h3 class="cmb-group-title cmbhandle-title"><span>', $field_group->replace_hash( $field_group->options( 'group_title' ) ), '</span></h3>
+			<h3 class="cmb-group-title cmbhandle-title"><span>', wp_kses_post( $field_group->replace_hash( $field_group->options( 'group_title' ) ) ), '</span></h3>
 
 			<div class="inside cmb-td cmb-nested cmb-field-list">';
 				// Loop and render repeatable group fields.

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1460,6 +1460,13 @@ class CMB2 extends CMB2_Base {
 		return $this->prop( 'context' ) && in_array( $this->prop( 'context' ), array( 'form_top', 'before_permalink', 'after_title', 'after_editor' ), true );
 	}
 
+	/**
+	 * Arguments for custom wp_kses sanitization/validation calls.
+	 *
+	 * @since  2.2.4
+	 * @param  string $type The field type being escaped.
+	 * @return array        An array of wp_kses HTML parameters allowed.
+	 */
 	public function kses_args( $type ) {
 		$params = array();
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -435,7 +435,7 @@ class CMB2 extends CMB2_Base {
 			$this->render_group_row( $field_group, $remove_disabled );
 		}
 
-		if ( $field_group->args( 'repeatable' ) ) {
+		if ( $this->is_repeatable( $field_group ) ) {
 			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button type="button" data-selector="', esc_attr( $field_group->id() ), '_repeat" data-grouptitle="', esc_attr( $field_group->options( 'group_title' ) ), '" class="cmb-add-group-row button-secondary">', esc_html( $field_group->options( 'add_button' ) ), '</button></p></div></div>';
 		}
 
@@ -456,7 +456,7 @@ class CMB2 extends CMB2_Base {
 	public function group_wrap_attributes( $field_group ) {
 		$classes = 'cmb-nested cmb-field-list cmb-repeatable-group';
 		$classes .= $field_group->options( 'sortable' ) ? ' sortable' : ' non-sortable';
-		$classes .= $field_group->args( 'repeatable' ) ? ' repeatable' : ' non-repeatable';
+		$classes .= $this->is_repeatable( $field_group ) ? ' repeatable' : ' non-repeatable';
 
 		$group_wrap_attributes = array(
 			'class' => $classes,
@@ -494,7 +494,7 @@ class CMB2 extends CMB2_Base {
 		echo '
 		<div class="postbox cmb-row cmb-repeatable-grouping', wp_kses( $closed_class, array() ), '" data-iterator="', absint( $field_group->index ), '">';
 
-		if ( $field_group->args( 'repeatable' ) ) {
+		if ( $this->is_repeatable( $field_group ) ) {
 			echo '<button type="button" ', wp_kses( $remove_disabled, $this->kses_args( 'remove_disabled' ) ), 'data-selector="', esc_attr( $field_group->id() ), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
 		}
 
@@ -518,7 +518,7 @@ class CMB2 extends CMB2_Base {
 				$field = $this->get_field( $field_args, $field_group )->render_field();
 			}
 		}
-		if ( $field_group->args( 'repeatable' ) ) {
+		if ( $this->is_repeatable( $field_group ) ) {
 			echo '
 					<div class="cmb-row cmb-remove-field-row">
 						<div class="cmb-remove-row">
@@ -1478,6 +1478,17 @@ class CMB2 extends CMB2_Base {
 		}
 
 		return $params;
+	}
+
+	/**
+	 * Helper function that returns whether a field group is repeatable or not.
+	 *
+	 * @since  2.2.4
+	 * @param  object $field_group The field group.
+	 * @return boolean
+	 */
+	public function is_repeatable( $field_group ) {
+		return $field_group->args( 'repeatable' );
 	}
 
 	/**

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -412,7 +412,7 @@ class CMB2 extends CMB2_Base {
 
 		$field_group->peform_param_callback( 'before_group' );
 
-		echo '<div class="cmb-row cmb-repeat-group-wrap ', esc_attr( $field_group->row_classes() ), '" data-fieldtype="group"><div class="cmb-td"><div data-groupid="', esc_attr( $field_group->id() ), '" id="', esc_attr( $field_group->id() ), '_repeat" ', wp_kses( $this->group_wrap_attributes( $field_group ), $this->kses_group_wrap_atts() ), '>';
+		echo '<div class="cmb-row cmb-repeat-group-wrap ', esc_attr( $field_group->row_classes() ), '" data-fieldtype="group"><div class="cmb-td"><div data-groupid="', esc_attr( $field_group->id() ), '" id="', esc_attr( $field_group->id() ), '_repeat" ', wp_kses( $this->group_wrap_attributes( $field_group ), $this->kses_args( 'group_wrap_attributes' ) ), '>';
 
 		if ( $desc || $label ) {
 			$class = $desc ? ' cmb-group-description' : '';

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -418,10 +418,10 @@ class CMB2 extends CMB2_Base {
 			$class = $desc ? ' cmb-group-description' : '';
 			echo '<div class="cmb-row', wp_kses( $class, array() ), '"><div class="cmb-th">';
 			if ( $label ) {
-				echo '<h2 class="cmb-group-name">', $label, '</h2>';
+				echo '<h2 class="cmb-group-name">', wp_kses_post( $label ), '</h2>';
 			}
 			if ( $desc ) {
-				echo '<p class="cmb2-metabox-description">', $desc, '</p>';
+				echo '<p class="cmb2-metabox-description">', wp_kses_post( $desc ), '</p>';
 			}
 			echo '</div></div>';
 		}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1465,13 +1465,13 @@ class CMB2 extends CMB2_Base {
 		$params = array();
 
 		switch ( $type ) {
-			case 'group_wrap_attributes' :
+			case 'group_wrap_attributes':
 				$params = array(
 					'class' => array(),
 					'style' => array(),
 				);
 				break;
-			case 'remove_disabled' :
+			case 'remove_disabled':
 				$params = array(
 					'disabled' => array(),
 				);

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -894,17 +894,17 @@ class CMB2 extends CMB2_Base {
 				break;
 
 			case 'comment':
-				$object_id = isset( $_REQUEST['c'] ) ? wp_unslash( $_REQUEST['c'] ) : $object_id;
+				$object_id = isset( $_REQUEST['c'] ) ? wp_unslash( absint( $_REQUEST['c'] ) ) : $object_id;
 				$object_id = ! $object_id && isset( $GLOBALS['comments']->comment_ID ) ? $GLOBALS['comments']->comment_ID : $object_id;
 				break;
 
 			case 'term':
-				$object_id = isset( $_REQUEST['tag_ID'] ) ? wp_unslash( $_REQUEST['tag_ID'] ) : $object_id;
+				$object_id = isset( $_REQUEST['tag_ID'] ) ? wp_unslash( absint( $_REQUEST['tag_ID'] ) ) : $object_id;
 				break;
 
 			default:
 				$object_id = isset( $GLOBALS['post']->ID ) ? $GLOBALS['post']->ID : $object_id;
-				$object_id = isset( $_REQUEST['post'] ) ? wp_unslash( $_REQUEST['post'] ) : $object_id;
+				$object_id = isset( $_REQUEST['post'] ) ? wp_unslash( absint( $_REQUEST['post'] ) ) : $object_id;
 				break;
 		}
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -622,7 +622,7 @@ class CMB2 extends CMB2_Base {
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save = array() ) {
 
 		// Fall-back to $_POST data if no data was passed.
-		$data_to_save = ! empty( $data_to_save ) ? $data_to_save : $_POST;
+		$this->data_to_save = ! empty( $data_to_save ) ? $data_to_save : $_POST;
 
 		$object_id = $this->object_id( $object_id );
 		$object_type = $this->object_type( $object_type );

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -495,7 +495,7 @@ class CMB2 extends CMB2_Base {
 		<div class="postbox cmb-row cmb-repeatable-grouping', wp_kses( $closed_class, array() ), '" data-iterator="', absint( $field_group->index ), '">';
 
 		if ( $field_group->args( 'repeatable' ) ) {
-			echo '<button type="button" ', $remove_disabled, 'data-selector="', $field_group->id(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
+			echo '<button type="button" ', wp_kses( $remove_disabled, $this->kses_args( 'remove_disabled' ) ), 'data-selector="', $field_group->id(), '_repeat" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
 		}
 
 			echo '

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -412,7 +412,7 @@ class CMB2 extends CMB2_Base {
 
 		$field_group->peform_param_callback( 'before_group' );
 
-		echo '<div class="cmb-row cmb-repeat-group-wrap ', esc_attr( $field_group->row_classes() ), '" data-fieldtype="group"><div class="cmb-td"><div data-groupid="', esc_attr( $field_group->id() ), '" id="', esc_attr( $field_group->id() ), '_repeat" ', $this->group_wrap_attributes( $field_group ), '>';
+		echo '<div class="cmb-row cmb-repeat-group-wrap ', esc_attr( $field_group->row_classes() ), '" data-fieldtype="group"><div class="cmb-td"><div data-groupid="', esc_attr( $field_group->id() ), '" id="', esc_attr( $field_group->id() ), '_repeat" ', wp_kses( $this->group_wrap_attributes( $field_group ), $this->kses_group_wrap_atts() ), '>';
 
 		if ( $desc || $label ) {
 			$class = $desc ? ' cmb-group-description' : '';

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -522,7 +522,7 @@ class CMB2 extends CMB2_Base {
 			echo '
 					<div class="cmb-row cmb-remove-field-row">
 						<div class="cmb-remove-row">
-							<button type="button" ', $remove_disabled, 'data-selector="', $field_group->id(), '_repeat" class="cmb-remove-group-row cmb-remove-group-row-button alignright button-secondary">', $field_group->options( 'remove_button' ), '</button>
+							<button type="button" ', wp_kses( $remove_disabled, $this->kses_args( 'remove_disabled' ) ), 'data-selector="', esc_attr( $field_group->id() ), '_repeat" class="cmb-remove-group-row cmb-remove-group-row-button alignright button-secondary">', esc_html( $field_group->options( 'remove_button' ) ), '</button>
 						</div>
 					</div>
 					';

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -416,7 +416,7 @@ class CMB2 extends CMB2_Base {
 
 		if ( $desc || $label ) {
 			$class = $desc ? ' cmb-group-description' : '';
-			echo '<div class="cmb-row', $class, '"><div class="cmb-th">';
+			echo '<div class="cmb-row', wp_kses( $class, array() ), '"><div class="cmb-th">';
 			if ( $label ) {
 				echo '<h2 class="cmb-group-name">', $label, '</h2>';
 			}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -621,8 +621,18 @@ class CMB2 extends CMB2_Base {
 	 */
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save = array() ) {
 
-		// Fall-back to $_POST data.
-		$this->data_to_save = ! empty( $data_to_save ) ? $data_to_save : $_POST;
+
+		if ( $data_to_save ) {
+			// If data was passed.
+			$this->data_to_save = $data_to_save;
+		} elseif ( wp_verify_nonce( $this->nonce ) ) {
+			// Fall-back to $_POST data if no data was passed.
+			$this->data_to_save = $_POST;
+		} else {
+			// If we failed the nonce check, don't save anything.
+			$this->data_to_save = array();
+		}
+
 		$object_id = $this->object_id( $object_id );
 		$object_type = $this->object_type( $object_type );
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -249,12 +249,14 @@ class CMB2 extends CMB2_Base {
 		$classes = array( 'cmb2-wrap', 'form-table' );
 
 		// Use the callback to fetch classes.
-		if ( $added_classes = $this->get_param_callback_result( 'classes_cb' ) ) {
+		$added_classes = $this->get_param_callback_result( 'classes_cb' );
+		if ( $added_classes ) {
 			$added_classes = is_array( $added_classes ) ? $added_classes : array( $added_classes );
 			$classes = array_merge( $classes, $added_classes );
 		}
 
-		if ( $added_classes = $this->prop( 'classes' ) ) {
+		$added_classes = $this->prop( 'classes' );
+		if ( $added_classes ) {
 			$added_classes = is_array( $added_classes ) ? $added_classes : array( $added_classes );
 			$classes = array_merge( $classes, $added_classes );
 		}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1026,7 +1026,7 @@ class CMB2 extends CMB2_Base {
 			$type = 'term';
 		}
 
-		if ( defined( 'DOING_AJAX' ) && isset( $_POST['action'] ) && 'add-tag' === $_POST['action'] ) {
+		if ( defined( 'DOING_AJAX' ) && wp_verify_nonce( $this->nonce ) && isset( $_POST['action'] ) && 'add-tag' === $_POST['action'] ) {
 			$type = 'term';
 		}
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1455,43 +1455,6 @@ class CMB2 extends CMB2_Base {
 	}
 
 	/**
-	 * Arguments for custom wp_kses sanitization/validation calls.
-	 *
-	 * @since  2.2.4
-	 * @param  string $type The field type being escaped.
-	 * @return array        An array of wp_kses HTML parameters allowed.
-	 */
-	public function kses_args( $type ) {
-		$params = array();
-
-		switch ( $type ) {
-			case 'group_wrap_attributes':
-				$params = array(
-					'class' => array(),
-					'style' => array(),
-				);
-				break;
-			case 'remove_disabled':
-				$params = array(
-					'disabled' => array(),
-				);
-		}
-
-		return $params;
-	}
-
-	/**
-	 * Helper function that returns whether a field group is repeatable or not.
-	 *
-	 * @since  2.2.4
-	 * @param  object $field_group The field group.
-	 * @return boolean
-	 */
-	public function is_repeatable( $field_group ) {
-		return $field_group->args( 'repeatable' );
-	}
-
-	/**
 	 * Magic getter for our object.
 	 *
 	 * @param  string $property Object property.

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1056,11 +1056,11 @@ class CMB2 extends CMB2_Base {
 	 * @return mixed            Metabox config property value or false.
 	 */
 	public function prop( $property, $fallback = null ) {
-		if ( array_key_exists( $property, $this->meta_box ) ) {
-			return $this->meta_box[ $property ];
-		} elseif ( $fallback ) {
-			return $this->meta_box[ $property ] = $fallback;
+		if ( ! array_key_exists( $property, $this->meta_box ) ) {
+			$this->meta_box[ $property ] = $fallback;
 		}
+
+		return $this->meta_box[ $property ];
 	}
 
 	/**

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -621,7 +621,6 @@ class CMB2 extends CMB2_Base {
 	 */
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save = array() ) {
 
-
 		if ( $data_to_save ) {
 			// If data was passed.
 			$this->data_to_save = $data_to_save;
@@ -1476,7 +1475,6 @@ class CMB2 extends CMB2_Base {
 					'disabled' => array(),
 				);
 		}
-
 
 		return $params;
 	}

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -933,14 +933,15 @@ class CMB2 extends CMB2_Base {
 		$registered_types = $this->box_types();
 
 		$type = '';
+		$curr_type = $this->current_object_type();
 
-		// if it's an array of one, extract it.
+		// If it's an array of one, extract it.
 		if ( 1 === count( $registered_types ) ) {
 			$last = end( $registered_types );
 			if ( is_string( $last ) ) {
 				$type = $last;
 			}
-		} elseif ( ( $curr_type = $this->current_object_type() ) && in_array( $curr_type, $registered_types, true ) ) {
+		} elseif ( $curr_type && in_array( $curr_type, $registered_types, true ) ) {
 			$type = $curr_type;
 		}
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -1412,7 +1412,7 @@ class CMB2 extends CMB2_Base {
 	 */
 	public function search_old_school_array( $field_id, $fields ) {
 		$ids = wp_list_pluck( $fields, 'id' );
-		$index = array_search( $field_id, $ids );
+		$index = array_search( $field_id, $ids, true );
 		return false !== $index ? $index : false;
 	}
 

--- a/includes/CMB2_Base.php
+++ b/includes/CMB2_Base.php
@@ -79,7 +79,7 @@ abstract class CMB2_Base {
 	 * Get started
 	 *
 	 * @since 2.2.3
-	 * @param array $args Object properties array
+	 * @param array $args Object properties array.
 	 */
 	public function __construct( $args = array() ) {
 		if ( ! empty( $args ) ) {
@@ -101,7 +101,7 @@ abstract class CMB2_Base {
 	 * Returns the object ID
 	 *
 	 * @since  2.2.3
-	 * @param  integer $object_id Object ID
+	 * @param  integer $object_id Object ID.
 	 * @return integer Object ID
 	 */
 	public function object_id( $object_id = 0 ) {
@@ -116,7 +116,7 @@ abstract class CMB2_Base {
 	 * Returns the object type
 	 *
 	 * @since  2.2.3
-	 * @param  string $object_type Object Type
+	 * @param  string $object_type Object Type.
 	 * @return string Object type
 	 */
 	public function object_type( $object_type = '' ) {
@@ -156,9 +156,9 @@ abstract class CMB2_Base {
 	 * Set object property.
 	 *
 	 * @since  2.2.2
-	 * @param  string $property Metabox config property to retrieve
-	 * @param  mixed  $value    Value to set if no value found
-	 * @return mixed            Metabox config property value or false
+	 * @param  string $property Metabox config property to retrieve.
+	 * @param  mixed  $value    Value to set if no value found.
+	 * @return mixed            Metabox config property value or false.
 	 */
 	public function set_prop( $property, $value ) {
 		$this->{$this->properties_name}[ $property ] = $value;
@@ -170,9 +170,9 @@ abstract class CMB2_Base {
 	 * Get object property and optionally set a fallback
 	 *
 	 * @since  2.0.0
-	 * @param  string $property Metabox config property to retrieve
-	 * @param  mixed  $fallback Fallback value to set if no value found
-	 * @return mixed            Metabox config property value or false
+	 * @param  string $property Metabox config property to retrieve.
+	 * @param  mixed  $fallback Fallback value to set if no value found.
+	 * @return mixed            Metabox config property value or false.
 	 */
 	public function prop( $property, $fallback = null ) {
 		if ( array_key_exists( $property, $this->{$this->properties_name} ) ) {
@@ -187,7 +187,7 @@ abstract class CMB2_Base {
 	 *
 	 * @since  2.2.0
 	 * @param  array      $field_args  Metabox field config array.
-	 * @param  CMB2_Field $field_group (optional) CMB2_Field object (group parent)
+	 * @param  CMB2_Field $field_group (optional) CMB2_Field object (group parent).
 	 * @return array                   Array of field arguments.
 	 */
 	protected function get_default_args( $field_args, $field_group = null ) {
@@ -213,7 +213,7 @@ abstract class CMB2_Base {
 	 *
 	 * @since  2.2.0
 	 * @param  array      $field_args  Metabox field config array.
-	 * @param  CMB2_Field $field_group (optional) CMB2_Field object (group parent)
+	 * @param  CMB2_Field $field_group (optional) CMB2_Field object (group parent).
 	 * @return CMB2_Field CMB2_Field object
 	 */
 	protected function get_new_field( $field_args, $field_group = null ) {
@@ -231,7 +231,7 @@ abstract class CMB2_Base {
 		// Default to showing this cmb
 		$show = true;
 
-		// Use the callback to determine showing the cmb, if it exists
+		// Use the callback to determine showing the cmb, if it exists.
 		if ( is_callable( $this->prop( 'show_on_cb' ) ) ) {
 			$show = (bool) call_user_func( $this->prop( 'show_on_cb' ), $this );
 		}
@@ -243,7 +243,7 @@ abstract class CMB2_Base {
 	 * Displays the results of the param callbacks.
 	 *
 	 * @since 2.0.0
-	 * @param string $param Field parameter
+	 * @param string $param Field parameter.
 	 */
 	public function peform_param_callback( $param ) {
 		echo $this->get_param_callback_result( $param );
@@ -253,15 +253,15 @@ abstract class CMB2_Base {
 	 * Store results of the param callbacks for continual access
 	 *
 	 * @since  2.0.0
-	 * @param  string $param Field parameter
+	 * @param  string $param Field parameter.
 	 * @return mixed         Results of param/param callback
 	 */
 	public function get_param_callback_result( $param ) {
 
-		// If we've already retrieved this param's value,
+		// If we've already retrieved this param's value...
 		if ( array_key_exists( $param, $this->callback_results ) ) {
 
-			// send it back
+			// ...send it back.
 			return $this->callback_results[ $param ];
 		}
 
@@ -292,7 +292,7 @@ abstract class CMB2_Base {
 	 * Handles the parameter callbacks, and passes this object as parameter.
 	 *
 	 * @since  2.2.3
-	 * @param  callable $cb The callback method/function/closure
+	 * @param  callable $cb The callback method/function/closure.
 	 * @return mixed        Return of the callback function.
 	 */
 	protected function do_callback( $cb ) {
@@ -303,7 +303,7 @@ abstract class CMB2_Base {
 	 * Checks if field has a callback value
 	 *
 	 * @since  1.0.1
-	 * @param  string $cb Callback string
+	 * @param  string $cb Callback string.
 	 * @return mixed      NULL, false for NO validation, or $cb string if it exists.
 	 */
 	public function maybe_callback( $cb ) {
@@ -312,10 +312,10 @@ abstract class CMB2_Base {
 			return null;
 		}
 
-		// Check if requesting explicitly false
+		// Check if requesting explicitly false.
 		$cb = false !== $args[ $cb ] && 'false' !== $args[ $cb ] ? $args[ $cb ] : false;
 
-		// If requesting NO validation, return false
+		// If requesting NO validation, return false.
 		if ( ! $cb ) {
 			return false;
 		}
@@ -340,7 +340,7 @@ abstract class CMB2_Base {
 	 *
 	 * @param  string $hook_name     The hook name.
 	 * @param  bool   $val           The default value.
-	 * @param  string $hook_function The hook function. Default: 'add_filter'
+	 * @param  string $hook_function The hook function. Default: 'add_filter'.
 	 *
 	 * @return null|bool             Null if hook is registered, or bool for value.
 	 */
@@ -491,8 +491,8 @@ abstract class CMB2_Base {
 	/**
 	 * Magic getter for our object.
 	 *
-	 * @param string $field
-	 * @throws Exception Throws an exception if the field is invalid.
+	 * @param  string $field Class property to get.
+	 * @throws Exception     Throws an exception if the field is invalid.
 	 * @return mixed
 	 */
 	public function __get( $field ) {
@@ -516,9 +516,10 @@ abstract class CMB2_Base {
 	/**
 	 * Allows overloading the object with methods... Whooaaa oooh it's magic, y'knoooow.
 	 *
-	 * @since 1.0.0
-	 * @param string $method Non-existent method.
-	 * @param array  $args   All arguments passed to the method
+	 * @since  1.0.0
+	 * @param  string $method Non-existent method.
+	 * @param  array  $args   All arguments passed to the method.
+	 * @throws Exception      Throws an exception if the method is invalid.
 	 */
 	public function __call( $method, $args ) {
 		$object_class = strtolower( get_class( $this ) );

--- a/includes/CMB2_Base.php
+++ b/includes/CMB2_Base.php
@@ -379,6 +379,43 @@ abstract class CMB2_Base {
 	}
 
 	/**
+	 * Arguments for custom wp_kses sanitization/validation calls.
+	 *
+	 * @since  2.2.4
+	 * @param  string $type The field type being escaped.
+	 * @return array        An array of wp_kses HTML parameters allowed.
+	 */
+	public function kses_args( $type ) {
+		$params = array();
+
+		switch ( $type ) {
+			case 'group_wrap_attributes':
+				$params = array(
+					'class' => array(),
+					'style' => array(),
+				);
+				break;
+			case 'remove_disabled':
+				$params = array(
+					'disabled' => array(),
+				);
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Helper function that returns whether a field group is repeatable or not.
+	 *
+	 * @since  2.2.4
+	 * @param  object $field_group The field group.
+	 * @return boolean
+	 */
+	public function is_repeatable( $field_group ) {
+		return $field_group->args( 'repeatable' );
+	}
+
+	/**
 	 * Mark a param as deprecated and inform when it has been used.
 	 *
 	 * There is a default WordPress hook deprecated_argument_run that will be called


### PR DESCRIPTION
Fixes (most) WPCS VIP sniffs. Sniffs that were not addressed:

```
    1 | ERROR   | [ ] Filenames should be all lowercase with hyphens
      |         |     as word separators. Expected cmb2.php, but
      |         |     found CMB2.php.
    1 | ERROR   | [ ] Class file names should be based on the class
      |         |     name with "class-" prepended. Expected
      |         |     class-cmb2.php, but found CMB2.php.
```

...and variations of:

```
  906 | WARNING | [ ] Detected access of super global var $_REQUEST,
      |         |     probably needs manual inspection.
 1028 | WARNING | [ ] Detected access of super global var $_POST,
      |         |     probably needs manual inspection.
```

Tested locally to pass unit tests but should have a sanity check.