### PR TITLE
Before and after form hooks order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 * New action hook, `cmb2_footer_enqueue`, which occurs after CMB2 enqueues its assets.
 * Example functions clean up. Props [@PavelK27](https://github.com/PavelK27) ([#866](https://github.com/CMB2/CMB2/pull/866)).
 * New `CMB2_Utils` methods, `get_available_image_sizes()` and `get_named_size()`. Props [@Cai333](https://github.com/Cai333). 
+* New before/after form hooks order. For more details see ([#954](https://github.com/CMB2/CMB2/pull/954)).
 
 ### Bug Fixes
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -324,18 +324,6 @@ class CMB2 extends CMB2_Base {
 		/**
 		 * Hook after form form has been rendered
 		 *
-		 * @param array  $cmb_id      The current box ID.
-		 * @param int    $object_id   The ID of the current object.
-		 * @param string $object_type The type of object you are working with.
-		 *	                           Usually `post` (this applies to all post-types).
-		 *	                           Could also be `comment`, `user` or `options-page`.
-		 * @param array  $cmb         This CMB2 object.
-		 */
-		do_action( 'cmb2_after_form', $this->cmb_id, $object_id, $object_type, $this );
-
-		/**
-		 * Hook after form form has been rendered
-		 *
 		 * The dynamic portion of the hook name, $this->cmb_id, is the meta_box id.
 		 *
 		 * The first dynamic portion of the hook name, $object_type, is the type of object
@@ -346,6 +334,18 @@ class CMB2 extends CMB2_Base {
 		 * @param array  $cmb         This CMB2 object
 		 */
 		do_action( "cmb2_after_{$object_type}_form_{$this->cmb_id}", $object_id, $this );
+
+		/**
+		 * Hook after form form has been rendered
+		 *
+		 * @param array  $cmb_id      The current box ID.
+		 * @param int    $object_id   The ID of the current object.
+		 * @param string $object_type The type of object you are working with.
+		 *	                           Usually `post` (this applies to all post-types).
+		 *	                           Could also be `comment`, `user` or `options-page`.
+		 * @param array  $cmb         This CMB2 object.
+		 */
+		do_action( 'cmb2_after_form', $this->cmb_id, $object_id, $object_type, $this );
 
 		echo "\n<!-- End CMB2 Fields -->\n";
 


### PR DESCRIPTION
This is a backwards-compatibility break. If your theme or plugin is using some of next action hooks and your are connecting the output between them then take a look a this explanation

Hooks have been called in this order (until this PR):
`cmb2_before_form`
`cmb2_before_{$object_type}_form_{$cmb_id}`
`cmb2_after_form`
`cmb2_after_{$object_type}_form_{$cmb_id}`

And now they are called at this order:
`cmb2_before_form`
`cmb2_before_{$object_type}_form_{$cmb_id}`
`cmb2_after_{$object_type}_form_{$cmb_id}`
`cmb2_after_form`

Why? Because this means call this hooks is really dangerous because you could break your html if you expect a relative order, for example, if two plugins using this hooks to print something, the most common workflow is use same relative callbacks (`cmb2_before_form` and `cmb2_after_form`) or (`cmb2_before_{$object_type}_form_{$cmb_id}` and `cmb2_after_{$object_type}_form_{$cmb_id}`) 

A visual example with two plugins (Plugin 1 and Plugin 2):
Current order:
`cmb2_before_form` Plugin 1 opens a div
`cmb2_before_{$object_type}_form_{$cmb_id}` Plugin 2 prints a p
`cmb2_after_form`  Plugin 1 closes the div
`cmb2_after_{$object_type}_form_{$cmb_id}` Plugin 2 closes the p

Result:
``` html
<div>
<p>
</div>
</p>
```

New order:
`cmb2_before_form` Plugin 1 opens a div
`cmb2_before_{$object_type}_form_{$cmb_id}` Plugin 2 prints a p
`cmb2_after_{$object_type}_form_{$cmb_id}` Plugin 2 closes the p
`cmb2_after_form`  Plugin 1 closes the div

Result:
``` html
<div>
<p>
</p>
</div>
```