### PR TITLE
Add the ability to use keys in group title

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -547,7 +547,7 @@ class CMB2 extends CMB2_Base {
 
 			echo '
 			<div class="cmbhandle" title="' , esc_attr__( 'Click to toggle', 'cmb2' ), '"><br></div>
-			<h3 class="cmb-group-title cmbhandle-title"><span>', $field_group->replace_hash( $field_group->options( 'group_title' ) ), '</span></h3>
+			<h3 class="cmb-group-title cmbhandle-title"><span>', $field_group->replace_keys( $field_group->options( 'group_title' ) ), '</span></h3>
 
 			<div class="inside cmb-td cmb-nested cmb-field-list">';
 				// Loop and render repeatable group fields.

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -993,6 +993,35 @@ class CMB2_Field extends CMB2_Base {
 	}
 
 	/**
+	 * Replaces keys with their value in the field
+	 *
+	 * @since  2.2.5
+	 * @param  string $value Value to update
+	 * @return string        Updated value
+	 */
+	public function replace_keys( $value ) {
+		preg_match_all( '#{([A-Za-z0-9_-]+)}#', $value, $matches );
+		if ( is_array( $matches ) ) {
+			foreach ( $matches[1] as $match ) {
+				if ( ! isset( $this->value[ $this->index ][ $match ] ) ) {
+					continue;
+				}
+
+				$key_value = $this->value[ $this->index ][ $match ];
+				if ( is_array( $key_value ) ) {
+					$key_value = implode( ', ', $key_value );
+				}
+
+				if ( is_string( $key_value ) ) {
+					$value = str_replace( '{' . $match . '}', $key_value, $value );
+				}
+			}
+		}
+
+		return $this->replace_hash( $value );
+	}
+
+	/**
 	 * Replaces a hash key - {#} - with the repeatable index
 	 *
 	 * @since  1.2.0


### PR DESCRIPTION
This PR introduces the ability to add field values into the group_title. For example

```
'options' => [
  'group_title'   => __( 'User {user_id} with roles: {user_roles}'  ),
  'add_button'    => __( 'Add Another User', 'cmb2' ),
  'remove_button' => __( 'Remove User', 'cmb2' ),
],
```

It will work for any fields that have a value of string or an array. If there are fields with other values it will ignore these. We could add more fields in the future but I think these are the main two people would want.

The reason for this change is that we have a repeatable field that has 100 entries and each field takes up the majority of the screen. With this change we can have the fields collapsed and an overview is shown for each collapsed field on what the values inside the field contain.