### PR TITLE
Cast variable

### DIFF
--- a/includes/CMB2_Options.php
+++ b/includes/CMB2_Options.php
@@ -200,14 +200,14 @@ class CMB2_Option {
 			$test_get = apply_filters( "cmb2_override_option_get_{$this->key}", 'cmb2_no_override_option_get', $default, $this );
 
 			if ( 'cmb2_no_override_option_get' !== $test_get ) {
-				$this->options = $test_get;
+				$this->options = (array) $test_get;
 			} else {
 				// If no override, get the option
-				$this->options = get_option( $this->key, $default );
+				$this->options = (array) get_option( $this->key, $default );
 			}
 		}
 
-		return (array) $this->options;
+		return $this->options;
 	}
 
 }

--- a/tests/test-cmb-core.php
+++ b/tests/test-cmb-core.php
@@ -314,6 +314,29 @@ class Test_CMB2_Core extends Test_CMB2 {
 		$this->assertEquals( $val, $new_value );
 	}
 
+	public function test_cmb2_with_empty_options() {
+		$opts = cmb2_options( 'cmb_empty_option' );
+		$this->assertInternalType( 'array', $opts->get_options() );
+	}
+
+	public function test_cmb2_get_option_with_empty_options() {
+		$opts = cmb2_options( 'cmb_empty_option' );
+		$this->assertFalse( $opts->get( 'nothing' ) );
+	}
+
+	public function test_cmb2_update_option_with_empty_options() {
+		$new_value = 'Van Anh';
+
+		cmb2_update_option( 'cmb_empty_option', 'my_name', $new_value );
+
+		$get = get_option( 'cmb_empty_option' );
+		$val = cmb2_get_option( 'cmb_empty_option', 'my_name' );
+
+		$this->assertEquals( $new_value, $get['my_name'] );
+		$this->assertEquals( $val, $get['my_name'] );
+		$this->assertEquals( $val, $new_value );
+	}
+
 	public function test_class_getters() {
 		$this->assertInstanceOf( 'CMB2_Ajax', cmb2_ajax() );
 		$this->assertInstanceOf( 'CMB2_Utils', cmb2_utils() );


### PR DESCRIPTION
The method just return cast `$this->options` as array but actually `$this->options` assign before still a string in some case.

Bugs will be show when I try empty cmb setting in `wp_options` table.
