### PR TITLE
Updates 'cmb2_can_save' filter

### DIFF
--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -915,7 +915,7 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 			&& ( $type && in_array( $type, $this->cmb->box_types() ) )
 			// Don't do updates during a switch-to-blog instance.
 			&& ! ( is_multisite() && ms_is_switched() )
-		) );
+		), $this->cmb );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this pull request

-  Adding the current CMB2 box object as a parameter to the 'cmb2_can_save' filter so we can identify which box is being saved.

-  It allows us to easily get and verify the box nonce into our custom filter for example.