### PR TITLE
Fixes invalid call to CMB2_Utils::filter_empty

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -918,8 +918,9 @@ class CMB2 extends CMB2_Base {
 				$saved[ $field_group->index ][ $sub_id ] = $new_val;
 
 			}// End foreach().
-
-			$saved[ $field_group->index ] = CMB2_Utils::filter_empty( $saved[ $field_group->index ] );
+			if (isset( $saved[ $field_group->index ] ) {
+				$saved[ $field_group->index ] = CMB2_Utils::filter_empty( $saved[ $field_group->index ] );
+			}
 		}// End foreach().
 
 		$saved = CMB2_Utils::filter_empty( $saved );


### PR DESCRIPTION
When the repeatable group field is empty (all groups are removed) a null value is sent to CMB2_Utils::filter_empty which expects an array and consecutively throws a php warning Warning: array_filter() expects parameter 1 to be array, null given
Since the values are not set, the array is never created in the previous foreach (the foreach does not run) but it is accessed using the index value of 0 set here: https://github.com/CMB2/CMB2/compare/trunk...Sharsie:group-field-save-patch?expand=1#diff-fdb2b24e1079e11eb3bb6accda8a8f90R864

Not creating an issue for this as this is just a simple check before accessing a non existent array key