### PR TITLE
Make CMB2_Option class properties public

### DIFF
--- a/includes/CMB2_Options.php
+++ b/includes/CMB2_Options.php
@@ -48,14 +48,14 @@ class CMB2_Option {
 	 *
 	 * @var array
 	 */
-	protected $options = array();
+	public $options = array();
 
 	/**
 	 * Current option key
 	 *
 	 * @var string
 	 */
-	protected $key = '';
+	public $key = '';
 
 	/**
 	 * Initiate option object


### PR DESCRIPTION
This class has two filters that pass `$this` but both properties are currently marked protected making this argument otherwise useless in the filter. Suggesting making them public so that any callbacks can access the properties and make use of them.

