### PR TITLE
Multidimensional Suport

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -875,15 +875,14 @@ class CMB2 extends CMB2_Base {
 	 * @return mixed                   Return of CMB2_Field::update_data().
 	 */
 	public function save_group_field( $field_group ) {
-		$base_id = $field_group->id();
-
-		if ( ! isset( $this->data_to_save[ $base_id ] ) ) {
+		$saved_value = $field_group->get_root_value_from_data( $this->data_to_save );
+		if ( is_null( $saved_value ) ) {
 			return;
 		}
 
 		$old        = $field_group->get_data();
 		// Check if group field has sanitization_cb.
-		$group_vals = $field_group->sanitization_cb( $this->data_to_save[ $base_id ] );
+		$group_vals = $field_group->sanitization_cb( $saved_value );
 		$saved      = array();
 
 		$field_group->index = 0;
@@ -936,7 +935,7 @@ class CMB2 extends CMB2_Base {
 
 				// Compare values and add to `$updated` array.
 				if ( $is_updated || $is_removed ) {
-					$this->updated[] = $base_id . '::' . $field_group->index . '::' . $sub_id;
+					$this->updated[] = $field_group->id() . '::' . $field_group->index . '::' . $sub_id;
 				}
 
 				// Add to `$saved` array.

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -33,6 +33,14 @@ class CMB2_Field extends CMB2_Base {
 	public $args = array();
 
 	/**
+	 * ID Data.
+	 *
+	 * @var   array
+	 * @since 2.2.6
+	 */
+	protected $id_data = array();
+
+	/**
 	 * Field group object or false (if no group)
 	 *
 	 * @var   mixed
@@ -137,6 +145,14 @@ class CMB2_Field extends CMB2_Base {
 		}
 
 		$this->args = $this->_set_field_defaults( $args['field_args'], $args );
+
+		// Parse the ID for array keys.
+		$this->id_data['keys'] = preg_split( '/\[/', str_replace( ']', '', $this->group ? $this->group->id( true ) : $this->id( true ) ) );
+		$this->id_data['base'] = array_shift( $this->id_data['keys'] );
+
+		if ( ! empty( $this->id_data['keys'] ) ) {
+			// ..
+		}
 
 		if ( $this->object_id ) {
 			$this->value = $this->get_data();
@@ -279,9 +295,11 @@ class CMB2_Field extends CMB2_Base {
 
 		// If no override, get value normally
 		if ( 'cmb2_field_no_override_val' === $data ) {
-			$data = 'options-page' === $a['type']
-				? cmb2_options( $a['id'] )->get( $a['field_id'] )
-				: get_metadata( $a['type'], $a['id'], $a['field_id'], ( $a['single'] || $a['repeat'] ) );
+			$data = $this->get_root_value( $a['single'] || $a['repeat'] );
+
+			if ( ! empty( $this->id_data['keys'] ) ) {
+				$data = $this->multidimensional_get( $data, $this->id_data['keys'] );
+			}
 		}
 
 		if ( $this->group ) {
@@ -349,23 +367,14 @@ class CMB2_Field extends CMB2_Base {
 			return $override;
 		}
 
-		// Options page handling (or temp data store)
-		if ( 'options-page' === $a['type'] || empty( $a['id'] ) ) {
-			return cmb2_options( $a['id'] )->update( $a['field_id'], $a['value'], false, $a['single'] );
-		}
+		if ( empty( $this->id_data['keys'] ) ) {
+			return $this->set_root_value( $a['value'], $a['single'] );
+		} else {
+			$root = $this->get_root_value( $a['single'] );
+			$root = $this->multidimensional_replace( $root, $this->id_data['keys'], $a['value'] );
 
-		// Add metadata if not single
-		if ( ! $a['single'] ) {
-			return add_metadata( $a['type'], $a['id'], $a['field_id'], $a['value'], false );
+			return $this->set_root_value( $root, $a['single'] );
 		}
-
-		// Delete meta if we have an empty array
-		if ( is_array( $a['value'] ) && empty( $a['value'] ) ) {
-			return delete_metadata( $a['type'], $a['id'], $a['field_id'], $this->value );
-		}
-
-		// Update metadata
-		return update_metadata( $a['type'], $a['id'], $a['field_id'], $a['value'] );
 	}
 
 	/**
@@ -423,14 +432,16 @@ class CMB2_Field extends CMB2_Base {
 		// If no override, remove as usual
 		if ( null !== $override ) {
 			return $override;
-		} // End if().
-		// Option page handling.
-		elseif ( 'options-page' === $a['type'] || empty( $a['id'] ) ) {
-			return cmb2_options( $a['id'] )->remove( $a['field_id'] );
 		}
 
-		// Remove metadata
-		return delete_metadata( $a['type'], $a['id'], $a['field_id'], $old );
+		if ( empty( $this->id_data['keys'] ) ) {
+			return $this->set_root_value( '', $a['single'] );
+		} else {
+			$root = $this->get_root_value( $a['single'] );
+			$root = $this->multidimensional_replace( $root, $this->id_data['keys'], '' );
+
+			return $this->set_root_value( $root, $a['single'] );
+		}
 	}
 
 	/**
@@ -503,6 +514,27 @@ class CMB2_Field extends CMB2_Base {
 	}
 
 	/**
+	 * Get root value from an array data.
+	 *
+	 * @since  2.2.6
+	 * @param  array $data The data like $_POST.
+	 * @return mixed
+	 */
+	public function get_root_value_from_data( array $data ) {
+		$id_base = $this->id_data['base'];
+
+		$value = array_key_exists( $id_base, $data )
+			? $data[ $id_base ]
+			: null;
+
+		if ( ! empty( $this->id_data['keys'] ) && is_array( $value ) ) {
+			$value = $this->multidimensional_get( $value, $this->id_data['keys'] );
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Process $_POST data to save this field's value
 	 *
 	 * @since  2.0.3
@@ -512,9 +544,7 @@ class CMB2_Field extends CMB2_Base {
 	public function save_field_from_data( array $data_to_save ) {
 		$this->data_to_save = $data_to_save;
 
-		$meta_value = isset( $this->data_to_save[ $this->id( true ) ] )
-			? $this->data_to_save[ $this->id( true ) ]
-			: null;
+		$meta_value = $this->get_root_value_from_data( $data_to_save );
 
 		return $this->save_field( $meta_value );
 	}
@@ -963,8 +993,6 @@ class CMB2_Field extends CMB2_Base {
 		return apply_filters( 'cmb2_row_classes', implode( ' ', $classes ), $this );
 	}
 
-
-
 	/**
 	 * Get field display callback and render the display value in the column.
 	 *
@@ -1260,7 +1288,9 @@ class CMB2_Field extends CMB2_Base {
 	 */
 	protected function set_group_sub_field_defaults( $args ) {
 		$args['id']    = $this->group->args( 'id' ) . '_' . $this->group->index . '_' . $args['id'];
-		$args['_name'] = $this->group->args( 'id' ) . '[' . $this->group->index . '][' . $args['_name'] . ']';
+
+		$keys = preg_split( '/\[/', str_replace( ']', '', $args['_name'] ) );
+		$args['_name'] = $this->group->args( 'id' ) . '[' . $this->group->index . '][' . implode( '][', $keys ) . ']';
 
 		return $args;
 	}
@@ -1408,6 +1438,168 @@ class CMB2_Field extends CMB2_Base {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Get the root value for a setting, especially for multidimensional ones.
+	 *
+	 * @since  2.2.6
+	 * @return mixed
+	 */
+	protected function get_root_value( $is_single = true ) {
+		$id_base = $this->id_data['base'];
+
+		return 'options-page' === $this->object_type
+			? cmb2_options( $this->object_id )->get( $id_base )
+			: get_metadata( $this->object_type, $this->object_id, $id_base, $is_single );
+	}
+
+	/**
+	 * Set the root value for a setting, especially for multidimensional ones.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param mixed $value Value to set as root of multidimensional setting.
+	 * @return bool Whether the multidimensional root was updated successfully.
+	 */
+	protected function set_root_value( $value, $is_single = true ) {
+		$id_base = $this->id_data['base'];
+
+		// Options page handling (or temp data store).
+		if ( 'options-page' === $this->object_type || empty( $this->object_id ) ) {
+			return cmb2_options( $this->object_id )->update( $id_base, $value, false, $is_single );
+		}
+
+		// Add metadata if not single.
+		if ( ! $is_single ) {
+			return add_metadata( $this->object_type, $this->object_id, $id_base, $value, false );
+		}
+
+		// Delete meta if we have an empty array.
+		if ( is_array( $value ) && empty( $value ) ) {
+			return delete_metadata( $this->object_type, $this->object_id, $id_base, $this->value );
+		}
+
+		// Update metadata.
+		return update_metadata( $this->object_type, $this->object_id, $id_base, $value );
+	}
+
+	/**
+	 * Multidimensional helper function.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param $root
+	 * @param $keys
+	 * @param bool $create Default is false.
+	 * @return array|void Keys are 'root', 'node', and 'key'.
+	 */
+	final protected function multidimensional( &$root, $keys, $create = false ) {
+		if ( $create && empty( $root ) ) {
+			$root = array();
+		}
+
+		if ( ! isset( $root ) || empty( $keys ) ) {
+			return;
+		}
+
+		$last = array_pop( $keys );
+		$node = &$root;
+
+		foreach ( $keys as $key ) {
+			if ( $create && ! isset( $node[ $key ] ) ) {
+				$node[ $key ] = array();
+			}
+
+			if ( ! is_array( $node ) || ! isset( $node[ $key ] ) ) {
+				return;
+			}
+
+			$node = &$node[ $key ];
+		}
+
+		if ( $create ) {
+			if ( ! is_array( $node ) ) {
+				// Account for an array overriding a string or object value.
+				$node = array();
+			}
+
+			if ( ! isset( $node[ $last ] ) ) {
+				$node[ $last ] = array();
+			}
+		}
+
+		if ( ! isset( $node[ $last ] ) ) {
+			return;
+		}
+
+		return array(
+			'root' => &$root,
+			'node' => &$node,
+			'key'  => $last,
+		);
+	}
+
+	/**
+	 * Will attempt to replace a specific value in a multidimensional array.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param $root
+	 * @param $keys
+	 * @param mixed $value The value to update.
+	 * @return mixed
+	 */
+	final protected function multidimensional_replace( $root, $keys, $value ) {
+		if ( ! isset( $value ) ) {
+			return $root;
+		} elseif ( empty( $keys ) ) { // If there are no keys, we're replacing the root.
+			return $value;
+		}
+
+		$result = $this->multidimensional( $root, $keys, true );
+
+		if ( isset( $result ) ) {
+			$result['node'][ $result['key'] ] = $value;
+		}
+
+		return $root;
+	}
+
+	/**
+	 * Will attempt to fetch a specific value from a multidimensional array.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param $root
+	 * @param $keys
+	 * @param mixed $default A default value which is used as a fallback. Default is null.
+	 * @return mixed The requested value or the default value.
+	 */
+	final protected function multidimensional_get( $root, $keys, $default = null ) {
+		// If there are no keys, test the root.
+		if ( empty( $keys ) ) {
+			return isset( $root ) ? $root : $default;
+		}
+
+		$result = $this->multidimensional( $root, $keys );
+
+		return isset( $result ) ? $result['node'][ $result['key'] ] : $default;
+	}
+
+	/**
+	 * Will attempt to check if a specific value in a multidimensional array is set.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param $root
+	 * @param $keys
+	 * @return bool True if value is set, false if not.
+	 */
+	final protected function multidimensional_isset( $root, $keys ) {
+		$result = $this->multidimensional_get( $root, $keys );
+
+		return isset( $result );
 	}
 
 }

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -435,10 +435,10 @@ class CMB2_Field extends CMB2_Base {
 		}
 
 		if ( empty( $this->id_data['keys'] ) ) {
-			return $this->set_root_value( '', $a['single'] );
+			return $this->remove_root_value( $old );
 		} else {
 			$root = $this->get_root_value( $a['single'] );
-			$root = $this->multidimensional_replace( $root, $this->id_data['keys'], '' );
+			$root = $this->multidimensional_replace( $root, $this->id_data['keys'], '' ); // TODO: Consider about this.
 
 			return $this->set_root_value( $root, $a['single'] );
 		}
@@ -1482,6 +1482,24 @@ class CMB2_Field extends CMB2_Base {
 
 		// Update metadata.
 		return update_metadata( $this->object_type, $this->object_id, $id_base, $value );
+	}
+
+	/**
+	 * Remove the root value for a setting, especially for multidimensional ones.
+	 *
+	 * @param  string $old_value The old value.
+	 * @return bool
+	 */
+	protected function remove_root_value( $old_value = '' ) {
+		$id_base = $this->id_data['base'];
+
+		// Options page handling (or temp data store).
+		if ( 'options-page' === $this->object_type || empty( $this->object_id ) ) {
+			return cmb2_options( $this->object_id )->remove( $id_base );
+		}
+
+		// Remove metadata.
+		return delete_metadata( $this->object_type, $this->object_id, $id_base, $old_value );
 	}
 
 	/**

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -437,10 +437,10 @@ class CMB2_Field extends CMB2_Base {
 		if ( empty( $this->id_data['keys'] ) ) {
 			return $this->remove_root_value( $old );
 		} else {
-			$root = $this->get_root_value( $a['single'] );
-			$root = $this->multidimensional_replace( $root, $this->id_data['keys'], '' ); // TODO: Consider about this.
+			$root = $this->get_root_value( $a['single'] || $a['repeat'] );
+			$root = $this->multidimensional_remove( $root, $this->id_data['keys'] );
 
-			return $this->set_root_value( $root, $a['single'] );
+			return $this->set_root_value( $root, $a['single'] || $a['repeat'] );
 		}
 	}
 
@@ -1556,6 +1556,29 @@ class CMB2_Field extends CMB2_Base {
 			'node' => &$node,
 			'key'  => $last,
 		);
+	}
+
+	/**
+	 * Will attempt to remove a specific value in a multidimensional array.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param $root
+	 * @param $keys
+	 * @return mixed
+	 */
+	final protected function multidimensional_remove( $root, $keys ) {
+		if ( empty( $keys ) ) { // If there are no keys, we're replacing the root.
+			return;
+		}
+
+		$result = $this->multidimensional( $root, $keys, true );
+
+		if ( isset( $result ) ) {
+			unset( $result['node'][ $result['key'] ] );
+		}
+
+		return $root;
 	}
 
 	/**

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -33,14 +33,6 @@ class CMB2_Field extends CMB2_Base {
 	public $args = array();
 
 	/**
-	 * ID Data.
-	 *
-	 * @var   array
-	 * @since 2.2.6
-	 */
-	protected $id_data = array();
-
-	/**
 	 * Field group object or false (if no group)
 	 *
 	 * @var   mixed
@@ -121,6 +113,14 @@ class CMB2_Field extends CMB2_Base {
 		'after_group_row',
 		'after_group',
 	);
+
+	/**
+	 * ID Data.
+	 *
+	 * @var   array
+	 * @since 2.2.x
+	 */
+	protected $id_data = array();
 
 	/**
 	 * Constructs our field object
@@ -516,7 +516,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Get root value from an array data.
 	 *
-	 * @since  2.2.6
+	 * @since  2.2.x
 	 * @param  array $data The data like $_POST.
 	 * @return mixed
 	 */
@@ -1443,7 +1443,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Get the root value for a setting, especially for multidimensional ones.
 	 *
-	 * @since  2.2.6
+	 * @since  2.2.x
 	 * @return mixed
 	 */
 	protected function get_root_value( $is_single = true ) {
@@ -1457,7 +1457,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Set the root value for a setting, especially for multidimensional ones.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param mixed $value Value to set as root of multidimensional setting.
 	 * @return bool Whether the multidimensional root was updated successfully.
@@ -1487,6 +1487,8 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Remove the root value for a setting, especially for multidimensional ones.
 	 *
+	 * @since 2.2.x
+	 *
 	 * @param  string $old_value The old value.
 	 * @return bool
 	 */
@@ -1505,7 +1507,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Multidimensional helper function.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param $root
 	 * @param $keys
@@ -1561,7 +1563,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Will attempt to remove a specific value in a multidimensional array.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param $root
 	 * @param $keys
@@ -1584,7 +1586,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Will attempt to replace a specific value in a multidimensional array.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param $root
 	 * @param $keys
@@ -1610,7 +1612,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Will attempt to fetch a specific value from a multidimensional array.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param $root
 	 * @param $keys
@@ -1631,7 +1633,7 @@ class CMB2_Field extends CMB2_Base {
 	/**
 	 * Will attempt to check if a specific value in a multidimensional array is set.
 	 *
-	 * @since 2.2.6
+	 * @since 2.2.x
 	 *
 	 * @param $root
 	 * @param $keys

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -150,10 +150,6 @@ class CMB2_Field extends CMB2_Base {
 		$this->id_data['keys'] = preg_split( '/\[/', str_replace( ']', '', $this->group ? $this->group->id( true ) : $this->id( true ) ) );
 		$this->id_data['base'] = array_shift( $this->id_data['keys'] );
 
-		if ( ! empty( $this->id_data['keys'] ) ) {
-			// ..
-		}
-
 		if ( $this->object_id ) {
 			$this->value = $this->get_data();
 		}

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -540,7 +540,7 @@ class CMB2_Field extends CMB2_Base {
 	public function save_field_from_data( array $data_to_save ) {
 		$this->data_to_save = $data_to_save;
 
-		$meta_value = $this->get_root_value_from_data( $data_to_save );
+		$meta_value = $this->get_root_value_from_data( $this->data_to_save );
 
 		return $this->save_field( $meta_value );
 	}


### PR DESCRIPTION
Fixes #776 

### Changes proposed in this pull request

Support field with array format like:

```php
$cmb_options->add_field( array(
	'name'    => esc_html__( 'Test multidimensional One', 'cmb2' ),
	'id'      => 'base[multidimensional]',
	'type'    => 'text',
) );

$cmb_options->add_field( array(
	'name'    => esc_html__( 'Test multidimensional One', 'cmb2' ),
	'id'      => 'base[multidimensional_repeatable]',
	'type'    => 'text',
	'repeatable' => true,
) );
```
### Summary

- [x] Work with normal fields
- [x] Work with repeatable fields
- [x] Work with group fields (not support items of group)
- [x] Write unit-tests