### PR TITLE
Page/Screen specific hook

### DIFF
--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -115,6 +115,13 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 		 */
 		do_action( 'cmb2_options_page_hook', $page_hook, $this->cmb );
 
+		/**
+		 * Fires for specific $page_hook value
+		 *
+		 * @param CMB2 $cmb The CMB2 object
+		 */
+		do_action( 'cmb2_options_page_hook_' . $page_hook, $this->cmb );
+		
 		$this->maybe_register_message();
 	}
 

--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -106,6 +106,15 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 			add_action( "admin_print_styles-{$page_hook}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
 		}
 
+		/**
+		 * For other page/screen specific hooks
+		 * like "load-{page_hook}"
+		 *
+		 * @param string	$page_hook The resulting page's hook_suffix.
+		 * @param CMB2 $cmb The CMB2 object
+		 */
+		do_action( 'cmb2_options_page_hook', $page_hook, $this->cmb );
+
 		$this->maybe_register_message();
 	}
 


### PR DESCRIPTION
Using the Page/Screen specific hooks is the most efficient way to target a callback for only the screen(s) you need it for, instead of more generic `init`, `admin_init`, `admin_footer` etc.

Some of the page specific hooks are:

- `load-{page_hook}`,
- `admin_print_styles-{page_hook}` (used just before this hook)
- `admin_print_scripts-{page_hook}`
- `admin_head-{page_hook}`
- `admin_footer-{page_hook}`

So, the added hook will make it easy to make use of these hooks explicitly. One of the best uses of this hook can be using `load-{page_hook}` to call [add_screen_option](https://developer.wordpress.org/reference/functions/add_screen_option/).