### PR TITLE
Ability to autoload=false for options. Closes #1093

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 * Enable linking options pages via tabbed-navigation. Will output tabbed navigation for options-pages which share the same `'tab_group'` CMB2 box property. [This snippet](https://github.com/CMB2/CMB2-Snippet-Library/blob/master/options-and-settings-pages/options-pages-with-tabs-and-submenus.php) demonstrates how to create a top-level menu options page with multiple submenu pages, each with the tabbed navigation. To specify a different tab title than the options-page title, set the `'tab_title'` CMB2 box property. See [#301](https://github.com/CMB2/CMB2/issues/301), [#627](https://github.com/CMB2/CMB2/issues/627).
 * Complete the `zh-CN` translation. Props [@uicestone](https://github.com/uicestone) ([#1089](https://github.com/CMB2/CMB2/issues/1089)).
+* Ability to disable the options autoload parameter via filter (`"cmb2_should_autoload_{$options_key}"`) or via a box parameter for `'options-page'` box registrations (`'autoload' => false,`). ([#1093](https://github.com/CMB2/CMB2/issues/1093))
 
 ## [2.3.0 - 2017-12-20](https://github.com/CMB2/CMB2/releases/tag/v2.3.0)
 

--- a/example-functions.php
+++ b/example-functions.php
@@ -670,6 +670,9 @@ function yourprefix_register_theme_options_metabox() {
 		// 'save_button'     => esc_html__( 'Save Theme Options', 'cmb2' ), // The text for the options-page save button. Defaults to 'Save'.
 		// 'disable_settings_errors' => true, // On settings pages (not options-general.php sub-pages), allows disabling.
 		// 'message_cb'      => 'yourprefix_options_page_message_callback',
+		// 'tab_group'       => '', // Tab-group identifier, enables options page tab navigation.
+		// 'tab_title'       => null, // Falls back to 'title' (above).
+		// 'autoload'        => false, // Defaults to true, the options-page option will be autloaded.
 	) );
 
 	/**

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -123,6 +123,7 @@ class CMB2 extends CMB2_Base {
 		'disable_settings_errors' => false, // On settings pages (not options-general.php sub-pages), allows disabling.
 		'tab_group'        => '', // Tab-group identifier, enables options page tab navigation.
 		// 'tab_title'    => null, // Falls back to 'title' (above). Do not define here so we can set a fallback.
+		// 'autoload'     => true, // Defaults to true, the options-page option will be autloaded.
 	);
 
 	/**

--- a/includes/CMB2_Options.php
+++ b/includes/CMB2_Options.php
@@ -193,7 +193,7 @@ class CMB2_Option {
 		$autoload = apply_filters( "cmb2_should_autoload_{$this->key}", true , $this );
 
 		// If no override, update the option
-		return update_option( $this->key, $this->options, $autoload ? null : false );
+		return update_option( $this->key, $this->options, (bool) $autoload );
 	}
 
 	/**

--- a/includes/CMB2_Options.php
+++ b/includes/CMB2_Options.php
@@ -180,8 +180,20 @@ class CMB2_Option {
 			return $test_save;
 		}
 
+		/**
+		 * Whether to auto-load the option when WordPress starts up.
+		 *
+		 * The dynamic portion of the hook name, $this->key, refers to the option key.
+		 *
+		 * @since 2.X.X
+		 *
+		 * @param bool        $autoload   Whether to load the option when WordPress starts up.
+		 * @param CMB2_Option $cmb_option This object.
+		 */
+		$autoload = apply_filters( "cmb2_should_autoload_{$this->key}", true , $this );
+
 		// If no override, update the option
-		return update_option( $this->key, $this->options );
+		return update_option( $this->key, $this->options, $autoload ? null : false );
 	}
 
 	/**

--- a/includes/CMB2_Options.php
+++ b/includes/CMB2_Options.php
@@ -177,6 +177,7 @@ class CMB2_Option {
 		$test_save = apply_filters( "cmb2_override_option_save_{$this->key}", 'cmb2_no_override_option_save', $this->options, $this );
 
 		if ( 'cmb2_no_override_option_save' !== $test_save ) {
+			// If override, do not proceed to update the option, just return result.
 			return $test_save;
 		}
 
@@ -190,10 +191,13 @@ class CMB2_Option {
 		 * @param bool        $autoload   Whether to load the option when WordPress starts up.
 		 * @param CMB2_Option $cmb_option This object.
 		 */
-		$autoload = apply_filters( "cmb2_should_autoload_{$this->key}", true , $this );
+		$autoload = apply_filters( "cmb2_should_autoload_{$this->key}", true, $this );
 
-		// If no override, update the option
-		return update_option( $this->key, $this->options, (bool) $autoload );
+		return update_option(
+			$this->key,
+			$this->options,
+			! $autoload || 'no' === $autoload ? false : true
+		);
 	}
 
 	/**

--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -45,6 +45,11 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 			return;
 		}
 
+		if ( ! $this->cmb->prop( 'autoload', true ) ) {
+			// Disable option autoload if requested.
+			add_filter( "cmb2_should_autoload_{$this->option_key}", '__return_false' );
+		}
+
 		// Register setting to cmb2 group.
 		register_setting( 'cmb2', $this->option_key );
 


### PR DESCRIPTION
Fixes #1093.

Ability to disable the options autoload parameter via filter (`"cmb2_should_autoload_{$options_key}"`) or via a box parameter for `'options-page'` box registrations (`'autoload' => false,`).