### PR TITLE
Call remove_default_tax_metaboxes from any type of post_hooks

### DIFF
--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -131,6 +131,7 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 				add_action( 'add_meta_boxes', array( $this, 'add_metaboxes' ) );
 		}
 
+		add_action( 'add_meta_boxes', array( $this, 'remove_default_tax_metaboxes' ) );
 		add_action( 'add_attachment', array( $this, 'save_post' ) );
 		add_action( 'edit_attachment', array( $this, 'save_post' ) );
 		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
@@ -508,10 +509,6 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 		add_filter( "postbox_classes_{$page}_{$this->cmb->cmb_id}", array( $this, 'postbox_classes' ) );
 
 		foreach ( $this->cmb->box_types() as $object_type ) {
-			if ( count( $this->cmb->tax_metaboxes_to_remove ) ) {
-				$this->remove_default_tax_metaboxes( $object_type );
-			}
-
 			add_meta_box( $this->cmb->cmb_id, $this->cmb->prop( 'title' ), array( $this, 'metabox_callback' ), $object_type, $this->cmb->prop( 'context' ), $this->cmb->prop( 'priority' ) );
 		}
 	}
@@ -520,16 +517,20 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	 * Remove the specified default taxonomy metaboxes for a post-type.
 	 *
 	 * @since 2.2.3
-	 * @param string $post_type Post type to remove the metabox for.
-	 */
-	protected function remove_default_tax_metaboxes( $post_type ) {
-		foreach ( $this->cmb->tax_metaboxes_to_remove as $taxonomy ) {
-			if ( ! taxonomy_exists( $taxonomy ) ) {
-				continue;
-			}
 
-			$mb_id = is_taxonomy_hierarchical( $taxonomy ) ? "{$taxonomy}div" : "tagsdiv-{$taxonomy}";
-			remove_meta_box( $mb_id, $post_type, 'side' );
+	 */
+	protected function remove_default_tax_metaboxes() {
+		foreach ( $this->cmb->box_types() as $post_type ) {
+			if ( count( $this->cmb->tax_metaboxes_to_remove ) ) {
+				foreach ( $this->cmb->tax_metaboxes_to_remove as $taxonomy ) {
+					if ( ! taxonomy_exists( $taxonomy ) ) {
+						continue;
+					}
+
+					$mb_id = is_taxonomy_hierarchical( $taxonomy ) ? "{$taxonomy}div" : "tagsdiv-{$taxonomy}";
+					remove_meta_box( $mb_id, $post_type, 'side' );
+				}
+			}
 		}
 	}
 

--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -517,16 +517,15 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	 * Remove the specified default taxonomy metaboxes for a post-type.
 	 *
 	 * @since 2.2.3
-
+	 *
 	 */
-	protected function remove_default_tax_metaboxes() {
-		foreach ( $this->cmb->box_types() as $post_type ) {
-			if ( count( $this->cmb->tax_metaboxes_to_remove ) ) {
-				foreach ( $this->cmb->tax_metaboxes_to_remove as $taxonomy ) {
-					if ( ! taxonomy_exists( $taxonomy ) ) {
+	public function remove_default_tax_metaboxes() {
+		foreach ( $this->cmb->box_types() as $post_type ){
+			if( count( $this->cmb->tax_metaboxes_to_remove ) ){
+				foreach( $this->cmb->tax_metaboxes_to_remove as $taxonomy ){
+					if( !taxonomy_exists( $taxonomy ) ){
 						continue;
 					}
-
 					$mb_id = is_taxonomy_hierarchical( $taxonomy ) ? "{$taxonomy}div" : "tagsdiv-{$taxonomy}";
 					remove_meta_box( $mb_id, $post_type, 'side' );
 				}


### PR DESCRIPTION
**v2.3.0** as well as tested against trunk.

**Issue**
Taxonomy fields accept a 'remove_default' parameter which unregisters the default term meta box on the post edit screens. This parameter works fine if you are using a standard meta box context when registering the meta box. However if you use another context such as 'after_title' this 'remove_default' parameter does nothing.

**To Recreate:**
Use a context when registering a box such as 'after_title'
Add a field of a taxonomy type and pass 'remove_default' to the field
See the default taxonomy meta box still exists on post edit screens

**Solution**
This pull request decouples the remove_default_tax_metabox() method from the add_metaboxes() method and calls it on it's own independent 'add_meta_boxes' action which allows the 'remove_default' param to work from any context. 