### PR TITLE
Updated the least required version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      jtsternberg, webdevstudios, tw2113
 Donate link:       https://cmb2.io
 Tags:              metaboxes, forms, fields, options, settings
-Requires at least: 3.8.0
+Requires at least: 4.7.0
 Tested up to:      4.9.6
 Stable tag:        2.4.2
 License:           GPLv2 or later


### PR DESCRIPTION
Fixes #1095 

The options page metaboxes crash for WP prior to 4.7 as discussed in #1095 