### PR TITLE
Fix the options page issue in WP prior to 4.7

### DIFF
--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -297,7 +297,7 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 			$url = add_query_arg( 'settings-updated', $updated ? 'true' : 'false', $url );
 		}
 
-		wp_safe_redirect( esc_url_raw( $url ), WP_Http::SEE_OTHER );
+		wp_safe_redirect( esc_url_raw( $url ), 303 );
 		exit;
 	}
 

--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -50,6 +50,17 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 			add_filter( "cmb2_should_autoload_{$this->option_key}", '__return_false' );
 		}
 
+		/**
+		 * for WP < 4.7
+		 *
+		 * @see https://core.trac.wordpress.org/ticket/37885
+		 */
+		global $wp_version;
+		if ( version_compare( $wp_version, '4.7', '<' ) ) {
+
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		// Register setting to cmb2 group.
 		register_setting( 'cmb2', $this->option_key );
 

--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -52,12 +52,9 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 
 		/**
 		 * for WP < 4.7
-		 *
-		 * @see https://core.trac.wordpress.org/ticket/37885
+		 * 
 		 */
-		global $wp_version;
-		if ( version_compare( $wp_version, '4.7', '<' ) ) {
-
+		if ( ! CMB2_Utils::wp_at_least( '4.7' ) && ! function_exists( 'register_setting' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 


### PR DESCRIPTION
Fixes #1095 and adds options page support for WP prior to 4.7, which otherwise crashed because of `register_setting` function been moved to `/wp-includes/option.php` in WP 4.7 because of [this](https://core.trac.wordpress.org/ticket/37885).
