### PR TITLE
Add a check for file existence

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -41,7 +41,11 @@ function cmb2_autoload_classes( $class_name ) {
 		$path .= '/rest-api';
 	}
 
-	include_once( cmb2_dir( "$path/{$class_name}.php" ) );
+	$path = cmb2_dir( "$path/{$class_name}.php" );
+
+	if ( file_exists( $path ) ) {
+		include_once( $path );
+	}
 }
 
 /**


### PR DESCRIPTION
Creating a custom field type whose classes (loaded by autoloader) start with CMB2 generated PHP warnings. So this conditional check prevents those warnings.
