### PR TITLE
use "call_user_func()" instead of direct call.

### DIFF
--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -190,7 +190,7 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 
 		$callback = $this->cmb->prop( 'display_cb' );
 		if ( is_callable( $callback ) ) {
-			return $callback( $this );
+			return call_user_func( $callback, $this );
 		}
 
 		$tabs = $this->get_tab_group_tabs();


### PR DESCRIPTION
Fixes the error caused when passing an object method to `display_cb`, therwise it results in **Fatal error**: **Function name must be a string in**