### PR TITLE
Support any type of markup when customizing repeating group row

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -641,7 +641,7 @@ window.CMB2 = window.CMB2 || {};
 		cmb.newRowHousekeeping( $row.data( 'title', $this.data( 'grouptitle' ) ) ).cleanRow( $row, prevNum, true );
 		$row.find( '.cmb-add-row-button' ).prop( 'disabled', false );
 
-		var $newRow = $( '<div class="postbox cmb-row cmb-repeatable-grouping" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</div>' );
+		var $newRow = $( '<' + $row.prop('nodeName') + ' class="postbox cmb-row cmb-repeatable-grouping" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</>' );
 		$oldRow.after( $newRow );
 
 		cmb.afterRowInsert( $newRow );


### PR DESCRIPTION
### Changes proposed in this pull request

Changing a groups markup can be accomplished quite easily using the `render_row_cb` argument when registering the group. If said customized group supported repeating and uses a `div` as the wrap of each group's fields, all repeat, delete, etc. group functionality works as expected.

However, If you use another element type such as `li` or `tr` in your customized group, the JS in it's current form will repeat the group as a `div` and not what it started as.

This one-liner fixes this edge case to support any element type with a customized group. 

