### PR TITLE
Remove superfluous method definitions

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -9,12 +9,6 @@
  * @author    CMB2 team
  * @license   GPL-2.0+
  * @link      https://cmb2.io
- *
- * @method string _id()
- * @method string _name()
- * @method string _desc()
- * @method string _text()
- * @method string concat_attrs()
  */
 class CMB2_Types {
 


### PR DESCRIPTION
This change removes unneeded method definitions from the class DocBlock. These methods are defined within the class, and so the `@method` tags aren't necessary (and in fact result in inspection errors in IDEs; in PhpStorm they trigger a "Method with same name already defined in this class" error).

Reference: http://docs.phpdoc.org/references/phpdoc/tags/method.html
