### PR TITLE
Use phpunit 6.5 on PHP 5.6

### DIFF
--- a/tests/bin/install-php-phpunit.sh
+++ b/tests/bin/install-php-phpunit.sh
@@ -25,6 +25,9 @@ mkdir -p $HOME/phpunit-bin
 if [[ ${SWITCH_TO_PHP:0:3} == "5.2" ]]; then
   # use the phpunit in the PHP5.2 installation
   ln -s ${PHP52_PATH}/lib/php/phpunit/phpunit.php $HOME/phpunit-bin/phpunit
+elif [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]] || [[ ${SWITCH_TO_PHP:0:3} == "5.6" ]]; then
+  wget -O $HOME/phpunit-bin/phpunit https://phar.phpunit.de/phpunit-6.5.phar
+  chmod +x $HOME/phpunit-bin/phpunit
 elif [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]] || [[ ${SWITCH_TO_PHP:0:2} == "5." ]]; then
   wget -O $HOME/phpunit-bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar
   chmod +x $HOME/phpunit-bin/phpunit


### PR DESCRIPTION
According to https://phpunit.de/getting-started/phpunit-4.html - phpunit 4 is for PHP 5.3-5.5.
phpunit 4-6 are for PHP 5.6.
Currently, on PHP 5.6 we install phpunit 4.8 which seems to just happen to work.
This PR adds a rule to install phpunit 6.5 on PHP 5.6.
Thus, we will use:
- special phpunit for PHP 5.2
- phpunit 4.8 for PHP 5.3-5.5
- phpunit 6.5 for PHP 5.6 and PHP 7.