### PR TITLE
Fix `rest_value_cb` registering of filter

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1014,7 +1014,7 @@ class CMB2_Field extends CMB2_Base {
 		$field_id   = $this->id( true );
 
 		if ( $cb = $this->maybe_callback( 'rest_value_cb' ) ) {
-			apply_filters( "cmb2_get_rest_value_for_{$field_id}", $cb, 99 );
+			add_filter( "cmb2_get_rest_value_for_{$field_id}", $cb, 99 );
 		}
 
 		$value = $this->get_data();


### PR DESCRIPTION
### Fixes: The usage of the rest_value_cb field property

The CMB2_Field has support for a (currently undocumented) property named `rest_value_cb` within the `get_rest_value` method. 

Currently, there is a `apply_filters` call which does nothing because it does have set a value when invoked. The second argument passed to `apply_filters` is 99 which suggests this is actually a priority vs a magic number. 

Changing `apply_filters` to `add_filter` allows this property to work while leaving the arguments intact. 

### Changes proposed in this pull request

Change `apply_filters` to `add_filter`.
