### PR TITLE
Making a field repeatable generates JS error because of missing sortable lib

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1332,6 +1332,11 @@ class CMB2_Field extends CMB2_Base {
 			true
 		);
 
+		// Repeatable fields require jQuery sortable library.
+		if ( ! empty( $args['repeatable'] ) ) {
+			CMB2_JS::add_dependencies( 'jquery-ui-sortable' );
+		}
+
 		return $args;
 	}
 

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -85,10 +85,6 @@ class CMB2_Types {
 	 */
 	public function render() {
 		if ( $this->field->args( 'repeatable' ) ) {
-
-			// Repeatable fields require jQuery sortable library.
-			$this->field->add_js_dependencies( 'jquery-ui-sortable' );
-
 			$this->render_repeatable_field();
 		} else {
 			$this->_render();

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -85,6 +85,10 @@ class CMB2_Types {
 	 */
 	public function render() {
 		if ( $this->field->args( 'repeatable' ) ) {
+
+			// Repeatable fields require jQuery sortable library.
+			$this->field->add_js_dependencies( 'jquery-ui-sortable' );
+
 			$this->render_repeatable_field();
 		} else {
 			$this->_render();

--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -1030,6 +1030,7 @@ class Test_CMB2_Types extends Test_CMB2_Types_Base {
 			'jquery-ui-datetimepicker' => 'jquery-ui-datetimepicker',
 			'media-editor'             => 'media-editor',
 			'wp-color-picker'          => 'wp-color-picker',
+			'jquery-ui-sortable'       => 'jquery-ui-sortable'
 		);
 
 		if ( CMB2_Utils::wp_at_least( '4.9.0' ) ) {


### PR DESCRIPTION
Fixes #1214.

### Changes proposed in this pull request

- When there is a repeatable field - register a `jquery-ui-sortable` lib as a dependency for default `cmb2.js`.

