### PR TITLE
Don't exclude composer.json from the distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,6 @@ node_modules       export-ignore
 package.json       export-ignore
 phpunit.xml        export-ignore
 tests              export-ignore
-composer.json      export-ignore
 readme.md          export-ignore
 README.md          export-ignore
 .idea              export-ignore


### PR DESCRIPTION
## Description

When installing CMB2 via Composer, the composer.json file gets excluded from the package. While this file isn't strictly needed, it helps if this file is in place when you're checking dependencies in your project.

In addition, the composer.lock file _doesn't_ get excluded, which is weird.

## Motivation and Context

After installing CMB2 via Composer, I wanted to quickly check its dependencies but was unable to do so.

## Risk Level

Low

## Testing procedure

1. Run `mkdir composer-export && git archive HEAD | tar -xC composer-export`
2. Verify that composer.json is present in the `composer-export` directory

## Types of changes

- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
