### PR TITLE
Add init.php to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
     "suggest": {
         "composer/installers": "~1.0"
     },
+    "autoload": {
+        "files": [
+            "init.php"
+        ]
+    },
     "require-dev": {
         "apigen/apigen": "4.1.2",
         "nette/utils": "2.5.3",


### PR DESCRIPTION
Add init.php to the composer.json file to autoload.

This is needed for use as a composer dependency.
Fixes #1185

## Risk
Minimal risk

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

