### PR TITLE
fix #1158, show on rest api only the fields of the post type

### DIFF
--- a/includes/rest-api/CMB2_REST.php
+++ b/includes/rest-api/CMB2_REST.php
@@ -400,17 +400,19 @@ class CMB2_REST extends CMB2_Hookup_Base {
 		if ( ! empty( self::$type_boxes[ $main_object_type ] ) ) {
 			foreach ( self::$type_boxes[ $main_object_type ] as $cmb_id ) {
 				$rest_box = self::$boxes[ $cmb_id ];
+				if( in_array( $object_type, $rest_box->cmb->meta_box['object_types'] ) ) {
 
-				foreach ( $rest_box->read_fields as $field_id ) {
-					$rest_box->cmb->object_id( $object['id'] );
-					$rest_box->cmb->object_type( $main_object_type );
+					foreach ( $rest_box->read_fields as $field_id ) {
+						$rest_box->cmb->object_id( $object['id'] );
+						$rest_box->cmb->object_type( $main_object_type );
 
-					$field = $rest_box->cmb->get_field( $field_id );
+						$field = $rest_box->cmb->get_field( $field_id );
 
-					$field->object_id( $object['id'] );
-					$field->object_type( $main_object_type );
+						$field->object_id( $object['id'] );
+						$field->object_type( $main_object_type );
 
-					$values[ $cmb_id ][ $field->id( true ) ] = $field->get_data();
+						$values[ $cmb_id ][ $field->id( true ) ] = $field->get_data();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description
Show on rest api only the fields of the specific post type instead right now that show all the registered fields in all the various metabox.

Basically the problem is that now when you define different metaboxes on various post types and open a rest api page and see the fields you can find all of them (also of other post types) as empty.
Checking the code the problem was that there is an array filled with all of them without a check if it is the right place to show them.

There are issues with the tests right now and need to be fixed before this patch is ready to be approved.

## Motivation and Context
Fixes #1158.

## Testing procedure
Create 2 metabox to 2 different post types and you will see only the fields of the post type thaty ou are looking on rest api (check in the ticket for an example of the code)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
