### PR TITLE
Feature: Adding possibility to use the meta value of a group field row in the collapsed heading

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -592,6 +592,21 @@ class CMB2 extends CMB2_Base {
 		$confirm_deletion = $field_group->options( 'remove_confirm' );
 		$confirm_deletion = ! empty( $confirm_deletion ) ? $confirm_deletion : '';
 
+        // for replacing {my_field_id} with the corresponding field value in repeaters
+        $replace_with_meta = function($heading) use ($field_group) {
+            if(isset($field_group->value[$field_group->index])) {
+                $values = $field_group->value[$field_group->index];
+                $fields = $field_group->args('fields');
+                foreach($fields as $id => $properties) {
+                    if(strpos($heading, '{'.$id.'}') !== false) {
+                        $replace = (is_scalar($values[$id])) ? strval($values[$id]) : '';
+                        $heading = str_replace('{'.$id.'}',$replace,$heading);
+                    }
+                }
+            }
+            return $heading;
+        };
+
 		echo '
 		<div id="cmb-group-', $field_group->id(), '-', $field_group->index, '" class="postbox cmb-row cmb-repeatable-grouping', $closed_class, '" data-iterator="', $field_group->index, '">';
 
@@ -601,7 +616,7 @@ class CMB2 extends CMB2_Base {
 
 			echo '
 			<div class="cmbhandle" title="' , esc_attr__( 'Click to toggle', 'cmb2' ), '"><br></div>
-			<h3 class="cmb-group-title cmbhandle-title"><span>', $field_group->replace_hash( $field_group->options( 'group_title' ) ), '</span></h3>
+			<h3 class="cmb-group-title cmbhandle-title"><span>', $replace_with_meta($field_group->replace_hash( $field_group->options( 'group_title' ) ) ), '</span></h3>
 
 			<div class="inside cmb-td cmb-nested cmb-field-list">';
 				// Loop and render repeatable group fields.


### PR DESCRIPTION
Feature: Adding possibility to use the meta value of a group field row in the collapsed heading

## Description
I was always missing this feature because if you have like 200 collapsed rows in a group field repeater you may search for hours for the correct entry. With this easy extension it is possible to add values from the group field to the title of the row. This is done by {field_id} (see example below).

## Motivation and Context
Not sure if an issue for this exists but I think it is an important new feature which I need for various projects.

## Risk Level
Minimal risk - as long as you do not put {meta_name} into the group fields title nothing can go wrong.

## Testing procedure
Look at the following example:

```
 $blog_group_id = $cmb->add_field( array(
        'id'          => 'endpoints',
        'type'        => 'group',
        'repeatable'  => true,
        'options'     => array(
            'group_title'   => __('Endpoint {#}: {path} ',CERR_PLUGIN_TEXTDOMAIN),
            'add_button'    => __( 'Add new', CERR_PLUGIN_TEXTDOMAIN ),
            'remove_button' => __( 'Remove', CERR_PLUGIN_TEXTDOMAIN ),
            'closed'        => true,  // Repeater fields closed by default - neat & compact.
            'sortable'      => true,  // Allow changing the order of repeated groups.
        ),
    ) );`

    $cmb->add_group_field( $blog_group_id, array(
        'name' => 'Path',
        'id'   => 'path',
        'type' => 'text',
    ) );
```

This extension only affects the "group_title" within the output. Endpoint {#}: {path} for instance may translate to Endpoint 1: /foo/bar

Please consider adding this to the core it would be valuable in my opinion. In case I have done anything wrong please tell me how I shall improve it.
