### PR TITLE
[Fixes #1250] Support custom groups with unique or without ids

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -672,7 +672,7 @@ window.CMB2 = window.CMB2 || {};
 		cmb.newRowHousekeeping( $row.data( 'title', $this.data( 'grouptitle' ) ) ).cleanRow( $row, prevNum, true );
 		$row.find( '.cmb-add-row-button' ).prop( 'disabled', false );
 
-		var $newRow = $( '<' + nodeName + ' class="postbox cmb-row cmb-repeatable-grouping" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</' + nodeName + '>' );
+		var $newRow = $( '<' + nodeName + ' class="' + $oldRow.attr('class') + '" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</' + nodeName + '>' );
 		if ( $oldRow.attr( 'id' ) !== undefined ) {
 			$newRow.attr( 'id', getRowId() );
 		}

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -655,9 +655,11 @@ window.CMB2 = window.CMB2 || {};
 		cmb.idNumber = parseInt( prevNum, 10 ) + 1;
 		var $row     = $oldRow.clone();
 		var nodeName = $row.prop('nodeName') || 'div';
-		var getRowId = function( id ) {
-			id = id.split('-');
-			id.splice(id.length - 1, 1);
+		var getRowId = function() {
+			var id = $oldRow.attr('id').split('-');
+			if ( ! isNaN( id[ id.length-1 ] ) ) {
+				id.splice( id.length - 1, 1 );
+			}
 			id.push( cmb.idNumber );
 			return id.join('-');
 		};
@@ -670,7 +672,11 @@ window.CMB2 = window.CMB2 || {};
 		cmb.newRowHousekeeping( $row.data( 'title', $this.data( 'grouptitle' ) ) ).cleanRow( $row, prevNum, true );
 		$row.find( '.cmb-add-row-button' ).prop( 'disabled', false );
 
-		var $newRow = $( '<' + nodeName + ' id="'+ getRowId( $oldRow.attr('id') ) +'" class="postbox cmb-row cmb-repeatable-grouping" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</' + nodeName + '>' );
+		var $newRow = $( '<' + nodeName + ' class="postbox cmb-row cmb-repeatable-grouping" data-iterator="'+ cmb.idNumber +'">'+ $row.html() +'</' + nodeName + '>' );
+		if ( $oldRow.attr( 'id' ) !== undefined ) {
+			$newRow.attr( 'id', getRowId() );
+		}
+
 		$oldRow.after( $newRow );
 
 		cmb.afterRowInsert( $newRow );


### PR DESCRIPTION
## Description

Fixes #1250 

This code accounts for 2 common scenarios when using `render_row_cb` to customize the markup used in groups. Currently, unless the rows include and follow the plugins's pattern exactly for ids, JS issues occur.

Scenarios this accounts for.

1. Rows which do not have ids.
2. Rows using their own style of ids which does not include the "-<row number>" at the end.

Bonus

1. Also uses the same classes for new rows which accounts for custom classes.



