### PR TITLE
Wrap the return of CMB2->box_classes() in sanitize_html_class() per VIP Feedback

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -347,8 +347,8 @@ class CMB2 extends CMB2_Base {
 		// Remove any duplicates.
 		$classes = array_unique( $classes );
 
-		// Make a string.
-		return implode( ' ', $classes );
+		// Make it a string and sanitize the class.
+		return sanitize_html_class( implode( ' ', $classes ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Wrapping the return of `CMB2->box_classes()` in `sanitize_html_class()` per WP VIP Feedback.

## Motivation and Context
Sanitizes the class of the CMB2 box.

## Risk Level
Minimal risk

## Testing procedure
1. Add filter to `cmb2_wrap_classes` to add some class names with quotes or special characters.
2. Create CMB2 metabox.
3. Check CMB2 metabox classes.

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).