### PR TITLE
Adding escaping to CMB2->render_group_callback() in order to address …

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -488,10 +488,10 @@ class CMB2 extends CMB2_Base {
 			$class = $desc ? ' cmb-group-description' : '';
 			echo '<div class="cmb-row', $class, '"><div class="cmb-th">';
 			if ( $label ) {
-				echo '<h2 class="cmb-group-name">', $label, '</h2>';
+				echo '<h2 class="cmb-group-name">', esc_html( $label ), '</h2>';
 			}
 			if ( $desc ) {
-				echo '<p class="cmb2-metabox-description">', $desc, '</p>';
+				echo '<p class="cmb2-metabox-description">', esc_html( $desc ), '</p>';
 			}
 			echo '</div></div>';
 		}
@@ -506,7 +506,7 @@ class CMB2 extends CMB2_Base {
 		}
 
 		if ( $field_group->args( 'repeatable' ) ) {
-			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button type="button" data-selector="', esc_attr( $field_group->id() ), '_repeat" data-grouptitle="', esc_attr( $field_group->options( 'group_title' ) ), '" class="cmb-add-group-row button-secondary">', $field_group->options( 'add_button' ), '</button></p></div></div>';
+			echo '<div class="cmb-row"><div class="cmb-td"><p class="cmb-add-row"><button type="button" data-selector="', esc_attr( $field_group->id() ), '_repeat" data-grouptitle="', esc_attr( $field_group->options( 'group_title' ) ), '" class="cmb-add-group-row button-secondary">', esc_html( $field_group->options( 'add_button' ) ), '</button></p></div></div>';
 		}
 
 		echo '</div></div></div>';


### PR DESCRIPTION
## Description
Adding escaping to `CMB2->render_group_callback()` for the label, description, and button content per WP VIP Feedback.

## Motivation and Context
Adds escaping to the label, description, and button content to pass WordPress-VIP-Go coding standards.

## Risk Level
Minimal risk

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).