### PR TITLE
Removing strip_tags() since it is already run in sanitize_text_field().

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -552,7 +552,7 @@ class CMB2 extends CMB2_Base {
 				$att_value = htmlspecialchars( $att_value );
 			}
 
-			$atts[ sanitize_html_class( $att ) ] = sanitize_text_field( strip_tags( $att_value ) );
+			$atts[ sanitize_html_class( $att ) ] = sanitize_text_field( $att_value );
 		}
 
 		return CMB2_Utils::concat_attrs( $atts );


### PR DESCRIPTION
## Description
Removing `strip_tags()` since it is already run within `sanitize_text_field()` per WP VIP Feedback.

## Motivation and Context
Removes unnecessary call to `strip_tags`.

## Risk Level
Minimal risk

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).