### PR TITLE
Ensure HTML classes are escaped

### DIFF
--- a/includes/CMB2_Field_Display.php
+++ b/includes/CMB2_Field_Display.php
@@ -129,7 +129,7 @@ class CMB2_Field_Display {
 			if ( is_array( $this->field->value ) ) {
 
 				// Then loop and output.
-				echo '<ul class="cmb2-' . str_replace( '_', '-', $this->field->type() ) . '">';
+				echo '<ul class="cmb2-' . esc_attr( sanitize_html_class( str_replace( '_', '-', $this->field->type() ) ) ) . '">';
 				foreach ( $this->field->value as $val ) {
 					$this->value = $val;
 					echo '<li>', $this->_display(), '</li>';
@@ -376,7 +376,7 @@ class CMB2_Display_Taxonomy_Multicheck extends CMB2_Field_Display {
 				$links[] = '<a href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a>';
 			}
 			// Then loop and output.
-			echo '<div class="cmb2-taxonomy-terms-', esc_attr( $taxonomy ), '">';
+			echo '<div class="cmb2-taxonomy-terms-', esc_attr( sanitize_html_class( $taxonomy ) ), '">';
 			echo implode( ', ', $links );
 			echo '</div>';
 		}

--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -196,7 +196,7 @@ class CMB2_Options_Hookup extends CMB2_hookup {
 
 		$tabs = $this->get_tab_group_tabs();
 		?>
-		<div class="wrap cmb2-options-page option-<?php echo $this->option_key; ?>">
+		<div class="wrap cmb2-options-page option-<?php echo esc_attr( sanitize_html_class( $this->option_key ) ); ?>">
 			<?php if ( $this->cmb->prop( 'title' ) ) : ?>
 				<h2><?php echo wp_kses_post( $this->cmb->prop( 'title' ) ); ?></h2>
 			<?php endif; ?>

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -398,7 +398,7 @@ class CMB2_Types {
 	protected function repeat_row( $class = 'cmb-repeat-row' ) {
 		?>
 
-		<div class="cmb-row <?php echo $class; ?>">
+		<div class="cmb-row <?php echo esc_attr( sanitize_html_class( $class ) ); ?>">
 			<div class="cmb-td">
 				<?php $this->_render(); ?>
 			</div>


### PR DESCRIPTION
## Description
Picking off some escaping/sanitizing from https://github.com/CMB2/CMB2/issues/1260. Ensures that classes with dynamically-inserted classes are properly escaped and (in this case) sanitized.

## Motivation and Context
Hardening escaping and sanitizing throughout the plugin.

## Risk Level
Minimal risk

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).


