### PR TITLE
Add late escaping to CMB2_Display_File

### DIFF
--- a/includes/CMB2_Field_Display.php
+++ b/includes/CMB2_Field_Display.php
@@ -429,7 +429,7 @@ class CMB2_Display_File extends CMB2_Field_Display {
 		} else {
 
 			printf( '<div class="file-status"><span>%1$s <strong><a href="%2$s">%3$s</a></strong></span></div>',
-				esc_html( $field_type->_text( 'file_text', esc_html__( 'File:', 'cmb2' ) ) ),
+				esc_html( $field_type->_text( 'file_text', __( 'File:', 'cmb2' ) ) ),
 				esc_url( $url_value ),
 				CMB2_Utils::get_file_name_from_path( esc_url( $url_value ) )
 			);

--- a/includes/CMB2_Field_Display.php
+++ b/includes/CMB2_Field_Display.php
@@ -421,7 +421,7 @@ class CMB2_Display_File extends CMB2_Field_Display {
 				) );
 			} else {
 				$size = is_array( $img_size ) ? $img_size[0] : 200;
-				$image = '<img class="cmb-image-display" style="max-width: ' . absint( $size ) . 'px; width: 100%; height: auto;" src="' . $url_value . '" alt="" />';
+				$image = '<img class="cmb-image-display" style="max-width: ' . absint( $size ) . 'px; width: 100%; height: auto;" src="' . esc_url( $url_value ) . '" alt="" />';
 			}
 
 			echo $image;
@@ -430,8 +430,8 @@ class CMB2_Display_File extends CMB2_Field_Display {
 
 			printf( '<div class="file-status"><span>%1$s <strong><a href="%2$s">%3$s</a></strong></span></div>',
 				esc_html( $field_type->_text( 'file_text', esc_html__( 'File:', 'cmb2' ) ) ),
-				$url_value,
-				CMB2_Utils::get_file_name_from_path( $url_value )
+				esc_url( $url_value ),
+				CMB2_Utils::get_file_name_from_path( esc_url( $url_value ) )
 			);
 
 		}

--- a/includes/CMB2_Field_Display.php
+++ b/includes/CMB2_Field_Display.php
@@ -431,7 +431,7 @@ class CMB2_Display_File extends CMB2_Field_Display {
 			printf( '<div class="file-status"><span>%1$s <strong><a href="%2$s">%3$s</a></strong></span></div>',
 				esc_html( $field_type->_text( 'file_text', __( 'File:', 'cmb2' ) ) ),
 				esc_url( $url_value ),
-				CMB2_Utils::get_file_name_from_path( esc_url( $url_value ) )
+				esc_html( CMB2_Utils::get_file_name_from_path( $url_value ) )
 			);
 
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Picking off some escaping/sanitizing from #1260. This PR late-escapes output from the `file_output` method of the `CMB2_Display_File` class. I realize that we're already escaping the URL in https://github.com/CMB2/CMB2/blob/develop/includes/CMB2_Field_Display.php#L397, but late-escaping is preferred and we could possibly get rid of the early-escaping from the link above.

## Motivation and Context
Hardening escaping and sanitizing throughout the plugin.

## Risk Level
Minimal risk

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
