### PR TITLE
Encode value to avoid php warning of converting array to string

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -590,9 +590,14 @@ class CMB2_Utils {
 			$excluded = in_array( $attr, (array) $attr_exclude, true );
 			$empty    = false === $val && 'value' !== $attr;
 			if ( ! $excluded && ! $empty ) {
-				// if data attribute, use single quote wraps, else double.
-				$quotes = self::is_data_attribute( $attr ) ? "'" : '"';
-				$attributes .= sprintf( ' %1$s=%3$s%2$s%3$s', $attr, $val, $quotes );
+				if (is_array($val)) {
+					// if $val is array, encode value to avoid php warning of converting array to string.
+					$attributes .= sprintf(' %1$s=%3$s%2$s%3$s', $attr, json_encode($val), "'");
+				} else {
+					// if data attribute, use single quote wraps, else double.
+					$quotes = self::is_data_attribute($attr) ? "'" : '"';
+					$attributes .= sprintf(' %1$s=%3$s%2$s%3$s', $attr, $val, $quotes);
+				}
 			}
 		}
 		return $attributes;


### PR DESCRIPTION
## Description
Check if value is an array before formatting the string

## Motivation and Context
Avoid PHP warning

## Risk Level
admin-only
