### PR TITLE
Added support for sortable columns

### DIFF
--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -425,14 +425,14 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 				continue;
 			}
 			
-			if( $field['id'] == $orderby ) {
+			if ( $field['id'] == $orderby ) {
 				$query->set( 'meta_key', $field['id'] );
 
-				if( $field['attributes']['type'] === 'number' ){
+				if ( $field['attributes']['type'] === 'number' ){
 					$query->set( 'orderby', 'meta_value_num' );
-				} elseif( $field['type'] === 'text_time' ) {
+				} elseif ( $field['type'] === 'text_time' ) {
 					$query->set( 'orderby', 'meta_value_time' );
-				} elseif( $field['type'] === 'text_date' ) {
+				} elseif ( $field['type'] === 'text_date' ) {
 					$query->set( 'orderby', 'meta_value_date' );
 				} else {
 					$query->set( 'orderby', 'meta_value' );

--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -350,11 +350,8 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 			$column = $field['column'];
 
 			if ( false === $column['position'] ) {
-
 				$columns[ $field['id'] ] = $column['name'];
-
 			} else {
-
 				$before = array_slice( $columns, 0, absint( $column['position'] ) );
 				$before[ $field['id'] ] = $column['name'];
 				$columns = $before + $columns;
@@ -392,6 +389,8 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	 * Returns the columns sortable array.
 	 *
 	 * @since 2.6.1
+	 *
+	 * @param array  $columns An array of sortable columns.
 	 */
 	public function columns_sortable( $columns ) {
 		$fields = $this->cmb->prop( 'fields' );
@@ -400,7 +399,6 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 			if ( ! isset( $field['column'] ) ) {
 				continue;
 			}
-
 			$columns[ $field['id'] ] = $field['id'];
 		}
 
@@ -411,13 +409,15 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	 * Return the order by on custom columns
 	 *
 	 * @since 2.6.1
+	 * 
+	 * @param array  $columns An array of sortable columns.
 	 */
 	public function columns_sortable_orderby( $query ) {
-		if( ! is_admin() )
+		if( ! is_admin() ){
 			return;
+		}
 	
-		$orderby = $query->get( 'orderby');
-		
+		$orderby = $query->get( 'orderby' );
 		$fields = $this->cmb->prop( 'fields' );
 
 		foreach ( $fields as $key => $field ) {
@@ -426,27 +426,17 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 			}
 			
 			if( $field['id'] == $orderby ) {
+				$query->set( 'meta_key', $field['id'] );
 
-				$query->set('meta_key', $field['id']);
-
-				if($field['attributes']['type'] == 'number'){
-
-					$query->set('orderby', 'meta_value_num');
-
-				} else if($field['type'] == 'text_time') {
-
-					$query->set('orderby', 'meta_value_time');
-
-				} else if($field['type'] == 'text_date') {
-
-					$query->set('orderby', 'meta_value_date');
-
+				if( $field['attributes']['type'] === 'number' ){
+					$query->set( 'orderby', 'meta_value_num' );
+				} elseif( $field['type'] === 'text_time' ) {
+					$query->set( 'orderby', 'meta_value_time' );
+				} elseif( $field['type'] === 'text_date' ) {
+					$query->set( 'orderby', 'meta_value_date' );
 				} else {
-
-					$query->set('orderby', 'meta_value');
-
+					$query->set( 'orderby', 'meta_value' );
 				}
-
 			}
 		}
 	}

--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -390,7 +390,9 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	 *
 	 * @since 2.6.1
 	 *
-	 * @param array  $columns An array of sortable columns.
+	 * @param array $columns An array of sortable columns.
+	 * 
+	 * @return array $columns An array of sortable columns with CMB2 columns.
 	 */
 	public function columns_sortable( $columns ) {
 		$fields = $this->cmb->prop( 'fields' );
@@ -406,14 +408,16 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 	}
 
 	/**
-	 * Return the order by on custom columns
+	 * Return the query object to order by custom columns if selected
 	 *
 	 * @since 2.6.1
 	 * 
-	 * @param array  $columns An array of sortable columns.
+	 * @param object $query Object query from WordPress
+	 * 
+	 * @return object $query Object query from WordPress with orderby CMB2 columns if selected
 	 */
 	public function columns_sortable_orderby( $query ) {
-		if( ! is_admin() ){
+		if ( ! is_admin() ) {
 			return;
 		}
 	
@@ -428,7 +432,7 @@ class CMB2_hookup extends CMB2_Hookup_Base {
 			if ( $field['id'] == $orderby ) {
 				$query->set( 'meta_key', $field['id'] );
 
-				if ( $field['attributes']['type'] === 'number' ){
+				if ( ! empty( $field['attributes']['type'] ) && 'number' === $field['attributes']['type'] ) {
 					$query->set( 'orderby', 'meta_value_num' );
 				} elseif ( $field['type'] === 'text_time' ) {
 					$query->set( 'orderby', 'meta_value_time' );


### PR DESCRIPTION
Added support to sort columns automatically by the type of field text, number, date or time.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added support to sort columns automatically in admin tables list when the "column" attribute is true.
This will sort by field type (text, number, date or time) using (query "orderby" -> meta_value, meta_value_num, meta_value_time or meta_value_date accordingly).

## Motivation and Context
There was a need to sort columns generated by CMB2 automatically without custom code. 
Fixes #831.

## Risk Level
minimal risk

## Testing procedure
Using the example-functions.php you can verify that the field with column attribute defined will automatically be able to sort. 

## Types of changes
**New feature (non-breaking change which adds functionality)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
- [ ] If this will be merged please verify the "[at]since" tag on the new functions created