### PR TITLE
Add description_cb to CMB2_Field

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -100,6 +100,7 @@ class CMB2_Field extends CMB2_Base {
 		'options_cb',
 		'text_cb',
 		'label_cb',
+		'description_cb',
 		'render_row_cb',
 		'display_cb',
 		'before_group',
@@ -926,6 +927,7 @@ class CMB2_Field extends CMB2_Base {
 
 		$types = new CMB2_Types( $this );
 		$types->render();
+		$this->peform_param_callback( 'description_cb' );
 
 		$this->peform_param_callback( 'after' );
 
@@ -967,6 +969,40 @@ class CMB2_Field extends CMB2_Base {
 		$style = ! $this->args( 'show_names' ) ? ' style="display:none;"' : '';
 
 		return sprintf( "\n" . '<label%1$s for="%2$s">%3$s</label>' . "\n", $style, $this->id(), $this->args( 'name' ) );
+	}
+
+
+	/**
+	 * The default description_cb callback
+	 *
+	 * @since  x.x.x
+	 * @return string Description html markup.
+	 */
+	public function description_callback() {
+		if ( ! $this->args( 'description' ) ) {
+			return '';
+		}
+
+		$paragraph_types = array(
+			'wysiwyg',
+			'title',
+			'textarea_code',
+			'textarea',
+			'datetime_timestamp_timezone',
+			'text',
+			'select',
+			'radio',
+			'multicheck',
+			'file',
+		);
+
+		$types = new CMB2_Types( $this );
+
+		if ( in_array( $this->args('type'), $paragraph_types) ){
+			return $types->_desc(true);
+		}else{
+			return $types->_desc();
+		}
 	}
 
 	/**
@@ -1514,6 +1550,7 @@ class CMB2_Field extends CMB2_Base {
 			'render_row_cb'     => array( $this, 'render_field_callback' ),
 			'display_cb'        => array( $this, 'display_value_callback' ),
 			'label_cb'          => 'title' !== $type ? array( $this, 'label' ) : '',
+			'description_cb'    =>  array( $this, 'description_callback' ),
 			'column'            => false,
 			'js_dependencies'   => array(),
 			'show_in_rest'      => null,

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -520,14 +520,12 @@ class CMB2_Types {
 	public function text_small() {
 		return $this->get_new_render_type( __FUNCTION__, 'CMB2_Type_Text', array(
 			'class' => 'cmb2-text-small',
-			'desc'  => $this->_desc(),
 		), 'input' )->render();
 	}
 
 	public function text_medium() {
 		return $this->get_new_render_type( __FUNCTION__, 'CMB2_Type_Text', array(
 			'class' => 'cmb2-text-medium',
-			'desc'  => $this->_desc(),
 		), 'input' )->render();
 	}
 
@@ -548,7 +546,6 @@ class CMB2_Types {
 	public function text_money() {
 		$input = $this->get_new_render_type( __FUNCTION__, 'CMB2_Type_Text', array(
 			'class' => 'cmb2-text-money',
-			'desc'  => $this->_desc(),
 		), 'input' )->render();
 		return ( ! $this->field->get_param_callback_result( 'before_field' ) ? '$ ' : ' ' ) . $input;
 	}

--- a/includes/types/CMB2_Type_Checkbox.php
+++ b/includes/types/CMB2_Type_Checkbox.php
@@ -61,14 +61,7 @@ class CMB2_Type_Checkbox extends CMB2_Type_Text {
 
 		$args = $this->parse_args( 'checkbox', $defaults );
 
-		return $this->rendered(
-			sprintf(
-				'%s <label for="%s">%s</label>',
-				parent::render( $args ),
-				$this->_id( '', false ),
-				$this->_desc()
-			)
-		);
+		return parent::render( $args );
 	}
 
 }

--- a/includes/types/CMB2_Type_Counter_Base.php
+++ b/includes/types/CMB2_Type_Counter_Base.php
@@ -112,7 +112,6 @@ abstract class CMB2_Type_Counter_Base extends CMB2_Type_Base {
 			if ( $max ) {
 				$attributes['maxlength'] = $max;
 			}
-			$attributes['desc'] = $char_counter . $attributes['desc'];
 		}
 
 		return $attributes;

--- a/includes/types/CMB2_Type_File.php
+++ b/includes/types/CMB2_Type_File.php
@@ -29,7 +29,6 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 			'name'            => $this->_name(),
 			'value'           => $field->escaped_value(),
 			'id_value'        => null,
-			'desc'            => $this->_desc( true ),
 			'size'            => 45,
 			'js_dependencies' => 'media-editor',
 			'preview_size'    => $field->args( 'preview_size' ),
@@ -56,7 +55,6 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 			'id'               => $a['id'],
 			'name'             => $a['name'],
 			'size'             => $a['size'],
-			'desc'             => '',
 			'data-previewsize' => sprintf( '[%d,%d]', $img_size_data['width'], $img_size_data['height'] ),
 			'data-sizename'    => $img_size_data['name'],
 			'data-queryargs'   => ! empty( $a['query_args'] ) ? json_encode( $a['query_args'] ) : '',
@@ -76,7 +74,6 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 			esc_attr( $this->_text( 'add_upload_file_text', esc_html__( 'Add or Upload File', 'cmb2' ) ) )
 		);
 
-		$output .= $a['desc'];
 		$output .= $this->get_id_field_output();
 
 		$output .= '<div id="' . $field->id() . '-status" class="cmb2-media-status">';
@@ -140,7 +137,6 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 			'type'  => 'hidden',
 			'class' => 'cmb2-upload-file-id',
 			'value' => $this->types->field->value,
-			'desc'  => '',
 		) );
 
 		// We need to put the original field object back

--- a/includes/types/CMB2_Type_File_List.php
+++ b/includes/types/CMB2_Type_File_List.php
@@ -27,7 +27,6 @@ class CMB2_Type_File_List extends CMB2_Type_File_Base {
 			'type'  => 'hidden',
 			'class' => 'cmb2-upload-file cmb2-upload-list',
 			'size'  => 45,
-			'desc'  => '',
 			'value'  => '',
 			'data-previewsize' => sprintf( '[%d,%d]', $img_size_data['width'], $img_size_data['height'] ),
 			'data-sizename'    => $img_size_data['name'],
@@ -54,7 +53,6 @@ class CMB2_Type_File_List extends CMB2_Type_File_Base {
 					'name'    => $name . '[' . $id . ']',
 					'id'      => 'filelist-' . $id,
 					'data-id' => $id,
-					'desc'    => '',
 					'class'   => false,
 				) );
 

--- a/includes/types/CMB2_Type_Multicheck.php
+++ b/includes/types/CMB2_Type_Multicheck.php
@@ -30,7 +30,6 @@ class CMB2_Type_Multicheck extends CMB2_Type_Radio {
 				'name'   => $this->_name() . '[]',
 				'method' => 'list_input_checkbox',
 			) ),
-			'desc' => $this->_desc( true ),
 		) );
 
 		return $this->rendered( $this->ul( $args ) );

--- a/includes/types/CMB2_Type_Radio.php
+++ b/includes/types/CMB2_Type_Radio.php
@@ -39,14 +39,13 @@ class CMB2_Type_Radio extends CMB2_Type_Multi_Base {
 				'label'  => 'test',
 				'method' => 'list_input',
 			) ),
-			'desc' => $this->_desc( true ),
 		) );
 
 		return $this->rendered( $this->ul( $args ) );
 	}
 
 	protected function ul( $a ) {
-		return sprintf( '<ul class="%s">%s</ul>%s', $a['class'], $a['options'], $a['desc'] );
+		return sprintf( '<ul class="%s">%s</ul>', $a['class'], $a['options'] );
 	}
 
 }

--- a/includes/types/CMB2_Type_Select.php
+++ b/includes/types/CMB2_Type_Select.php
@@ -17,14 +17,13 @@ class CMB2_Type_Select extends CMB2_Type_Multi_Base {
 			'class'   => 'cmb2_select',
 			'name'    => $this->_name(),
 			'id'      => $this->_id(),
-			'desc'    => $this->_desc( true ),
 			'options' => $this->concat_items(),
 		) );
 
-		$attrs = $this->concat_attrs( $a, array( 'desc', 'options' ) );
+		$attrs = $this->concat_attrs( $a, array( 'options' ) );
 
 		return $this->rendered(
-			sprintf( '<select%s>%s</select>%s', $attrs, $a['options'], $a['desc'] )
+			sprintf( '<select%s>%s</select>', $attrs, $a['options'] )
 		);
 	}
 }

--- a/includes/types/CMB2_Type_Select_Timezone.php
+++ b/includes/types/CMB2_Type_Select_Timezone.php
@@ -21,7 +21,6 @@ class CMB2_Type_Select_Timezone extends CMB2_Type_Select {
 		$this->args = wp_parse_args( $this->args, array(
 			'class'   => 'cmb2_select cmb2-select-timezone',
 			'options' => wp_timezone_choice( $this->field->escaped_value() ),
-			'desc'    => $this->_desc(),
 		) );
 
 		return parent::render();

--- a/includes/types/CMB2_Type_Text.php
+++ b/includes/types/CMB2_Type_Text.php
@@ -47,7 +47,6 @@ class CMB2_Type_Text extends CMB2_Type_Counter_Base {
 			'name'            => $this->_name(),
 			'id'              => $this->_id(),
 			'value'           => $this->field->escaped_value(),
-			'desc'            => $this->_desc( true ),
 			'js_dependencies' => array(),
 		), $args );
 
@@ -55,7 +54,7 @@ class CMB2_Type_Text extends CMB2_Type_Counter_Base {
 		$a = $this->maybe_update_attributes_for_char_counter( $a );
 
 		return $this->rendered(
-			sprintf( '<input%s/>%s', $this->concat_attrs( $a, array( 'desc' ) ), $a['desc'] )
+			sprintf( '<input%s/>', $this->concat_attrs( $a ) )
 		);
 	}
 }

--- a/includes/types/CMB2_Type_Text_Date.php
+++ b/includes/types/CMB2_Type_Text_Date.php
@@ -16,7 +16,6 @@ class CMB2_Type_Text_Date extends CMB2_Type_Picker_Base {
 		$args = $this->parse_args( 'text_date', array(
 			'class'           => 'cmb2-text-small cmb2-datepicker',
 			'value'           => $this->field->get_timestamp_format(),
-			'desc'            => $this->_desc(),
 			'js_dependencies' => array( 'jquery-ui-core', 'jquery-ui-datepicker' ),
 		) );
 

--- a/includes/types/CMB2_Type_Text_Datetime_Timestamp.php
+++ b/includes/types/CMB2_Type_Text_Datetime_Timestamp.php
@@ -22,7 +22,6 @@ class CMB2_Type_Text_Datetime_Timestamp extends CMB2_Type_Picker_Base {
 
 		$args = wp_parse_args( $this->args, array(
 			'value'      => $value,
-			'desc'       => $this->_desc(),
 			'datepicker' => array(),
 			'timepicker' => array(),
 		) );
@@ -50,7 +49,6 @@ class CMB2_Type_Text_Datetime_Timestamp extends CMB2_Type_Picker_Base {
 			'name'  => $this->_name( '[date]' ),
 			'id'    => $this->_id( '_date' ),
 			'value' => $has_good_value ? $this->field->get_timestamp_format( 'date_format', $args['value'] ) : '',
-			'desc'  => '',
 		) );
 
 		$date_args['rendered'] = true;
@@ -65,7 +63,6 @@ class CMB2_Type_Text_Datetime_Timestamp extends CMB2_Type_Picker_Base {
 			'name'  => $this->_name( '[time]' ),
 			'id'    => $this->_id( '_time' ),
 			'value' => $has_good_value ? $this->field->get_timestamp_format( 'time_format', $args['value'] ) : '',
-			'desc'  => $args['desc'],
 			'js_dependencies' => array( 'jquery-ui-core', 'jquery-ui-datepicker', 'jquery-ui-datetimepicker' ),
 		) );
 

--- a/includes/types/CMB2_Type_Text_Datetime_Timestamp_Timezone.php
+++ b/includes/types/CMB2_Type_Text_Datetime_Timestamp_Timezone.php
@@ -22,7 +22,6 @@ class CMB2_Type_Text_Datetime_Timestamp_Timezone extends CMB2_Type_Base {
 
 		$args = wp_parse_args( $this->args, array(
 			'value'                   => $value,
-			'desc'                    => $this->_desc( true ),
 			'text_datetime_timestamp' => array(),
 			'select_timezone'         => array(),
 		) );
@@ -42,7 +41,6 @@ class CMB2_Type_Text_Datetime_Timestamp_Timezone extends CMB2_Type_Base {
 		}
 
 		$timestamp_args = wp_parse_args( $args['text_datetime_timestamp'], array(
-			'desc'     => '',
 			'value'    => $value,
 			'rendered' => true,
 		) );
@@ -53,7 +51,6 @@ class CMB2_Type_Text_Datetime_Timestamp_Timezone extends CMB2_Type_Base {
 			'name'     => $this->_name( '[timezone]' ),
 			'id'       => $this->_id( '_timezone' ),
 			'options'  => wp_timezone_choice( $tzstring ),
-			'desc'     => $args['desc'],
 			'rendered' => true,
 		) );
 		$select = $this->types->select( $timezone_select_args );

--- a/includes/types/CMB2_Type_Textarea.php
+++ b/includes/types/CMB2_Type_Textarea.php
@@ -28,14 +28,13 @@ class CMB2_Type_Textarea extends CMB2_Type_Counter_Base {
 			'cols'  => 60,
 			'rows'  => 10,
 			'value' => $this->field->escaped_value( 'esc_textarea' ),
-			'desc'  => $this->_desc( true ),
 		), $args );
 
 		// Add character counter?
 		$a = $this->maybe_update_attributes_for_char_counter( $a );
 
 		return $this->rendered(
-			sprintf( '<textarea%s>%s</textarea>%s', $this->concat_attrs( $a, array( 'desc', 'value' ) ), $a['value'], $a['desc'] )
+			sprintf( '<textarea%s>%s</textarea>', $this->concat_attrs( $a, array( 'value' ) ), $a['value'] )
 		);
 	}
 }

--- a/includes/types/CMB2_Type_Textarea_Code.php
+++ b/includes/types/CMB2_Type_Textarea_Code.php
@@ -22,7 +22,6 @@ class CMB2_Type_Textarea_Code extends CMB2_Type_Textarea {
 	public function render( $args = array() ) {
 		$args = wp_parse_args( $args, array(
 			'class' => 'cmb2-textarea-code',
-			'desc'  => '</pre>' . $this->_desc( true ),
 		) );
 
 		if ( true !== $this->field->options( 'disable_codemirror' )
@@ -33,7 +32,7 @@ class CMB2_Type_Textarea_Code extends CMB2_Type_Textarea {
 		}
 
 		return $this->rendered(
-			sprintf( '<pre>%s', parent::render( $args ) )
+			sprintf( '<pre>%s</pre>', parent::render( $args ) )
 		);
 	}
 }

--- a/includes/types/CMB2_Type_Title.php
+++ b/includes/types/CMB2_Type_Title.php
@@ -29,17 +29,15 @@ class CMB2_Type_Title extends CMB2_Type_Base {
 			'tag'   => $tag,
 			'class' => empty( $name ) ? 'cmb2-metabox-title-anchor' : 'cmb2-metabox-title',
 			'name'  => $name,
-			'desc'  => $this->_desc( true ),
 			'id'    => str_replace( '_', '-', sanitize_html_class( $this->field->id() ) ),
 		) );
 
 		return $this->rendered(
 			sprintf(
-				'<%1$s %2$s>%3$s</%1$s>%4$s',
+				'<%1$s %2$s>%3$s</%1$s>',
 				$a['tag'],
-				$this->concat_attrs( $a, array( 'tag', 'name', 'desc' ) ),
-				$a['name'],
-				$a['desc']
+				$this->concat_attrs( $a, array( 'tag', 'name' ) ),
+				$a['name']
 			)
 		);
 	}

--- a/includes/types/CMB2_Type_Wysiwyg.php
+++ b/includes/types/CMB2_Type_Wysiwyg.php
@@ -11,7 +11,6 @@
  * @link      https://cmb2.io
  *
  * @method string _id()
- * @method string _desc()
  */
 class CMB2_Type_Wysiwyg extends CMB2_Type_Textarea {
 
@@ -25,7 +24,6 @@ class CMB2_Type_Wysiwyg extends CMB2_Type_Textarea {
 		$a = $this->parse_args( 'wysiwyg', array(
 			'id'      => $this->_id( '', false ),
 			'value'   => $field->escaped_value( 'stripslashes' ),
-			'desc'    => $this->_desc( true ),
 			'options' => $field->options(),
 		) );
 
@@ -39,7 +37,7 @@ class CMB2_Type_Wysiwyg extends CMB2_Type_Textarea {
 					: 'cmb2-count-chars';
 			}
 
-			return $this->rendered( $this->get_wp_editor( $a ) . $a['desc'] );
+			return $this->rendered( $this->get_wp_editor( $a ) );
 		}
 
 		// Character counter not currently working for grouped WYSIWYG
@@ -52,13 +50,17 @@ class CMB2_Type_Wysiwyg extends CMB2_Type_Textarea {
 		add_action( is_admin() ? 'admin_footer' : 'wp_footer', array( $this, 'add_wysiwyg_template_for_group' ) );
 
 		return $this->rendered(
-			sprintf( '<div class="cmb2-wysiwyg-wrap">%s', parent::render( array(
-				'class'         => 'cmb2_textarea cmb2-wysiwyg-placeholder',
-				'data-groupid'  => $field->group->id(),
-				'data-iterator' => $field->group->index,
-				'data-fieldid'  => $field->id( true ),
-				'desc'          => '</div>' . $this->_desc( true ),
-			) ) )
+			sprintf(
+				'<div class="cmb2-wysiwyg-wrap">%s</div>',
+				parent::render(
+					array(
+						'class'         => 'cmb2_textarea cmb2-wysiwyg-placeholder',
+						'data-groupid'  => $field->group->id(),
+						'data-iterator' => $field->group->index,
+						'data-fieldid'  => $field->id( true ),
+					)
+				)
+			)
 		);
 	}
 


### PR DESCRIPTION
## Description
Added `description_cb` callback to `CMB_Field` and changed `CMB2_Type_*::render()` methods to only print the atomic html tag and not print the description. Description now rendered exclusively by `description_cb` callback.

## Motivation and Context
Fixes #1293.

## Risk Level
admin-only = minimal risk

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
I did not run any unit-tests.
I did prints out a page with all field types, including group, and including one external field type ("switch") I've installed locally.
This works well with all built-in field types.
The switch field printed the description twice (obviously). One was the switch's hardcoded description, followed by the new description_cb callback. So I'm guessing this could be considered some sort of breaking change. YMMV

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **New feature (non-breaking change which adds functionality)**
- **Breaking change (fix or feature that would cause existing functionality to change)**
It's one of the above - that's for sure.

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code (_maybe_) follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

