### PR TITLE
Escaping improvements to File Fields

### DIFF
--- a/includes/types/CMB2_Type_File.php
+++ b/includes/types/CMB2_Type_File.php
@@ -79,7 +79,7 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 		$output .= $a['desc'];
 		$output .= $this->get_id_field_output();
 
-		$output .= '<div id="' . $field->id() . '-status" class="cmb2-media-status">';
+		$output .= '<div id="' . esc_attr( $field->id() ) . '-status" class="cmb2-media-status">';
 		if ( ! empty( $a['value'] ) ) {
 			$output .= $this->get_file_preview_output();
 		}
@@ -110,7 +110,7 @@ class CMB2_Type_File extends CMB2_Type_File_Base {
 				'class' => 'cmb-file-field-image',
 			) );
 		} else {
-			$image = '<img style="max-width: ' . absint( $this->args['img_size_data']['width'] ) . 'px; width: 100%;" src="' . $this->args['value'] . '" class="cmb-file-field-image" alt="" />';
+			$image = '<img style="max-width: ' . absint( $this->args['img_size_data']['width'] ) . 'px; width: 100%;" src="' . esc_url( $this->args['value'] ) . '" class="cmb-file-field-image" alt="" />';
 		}
 
 		return $this->img_status_output( array(


### PR DESCRIPTION
Adds some attribute escaping that was missed

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds additional escaping to the file field

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This improves the security of the file field type

## Risk Level

admin-only, minimal risk

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the code and confirmed no changes in WP Admin

## Types of changes

- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

