### PR TITLE
Include .CodeMirror class in sortable exclusions

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -1024,7 +1024,8 @@ window.CMB2 = window.CMB2 || {};
 		if ( $repeatables.length ) {
 			$repeatables.sortable({
 				items : '.cmb-repeat-row',
-				cursor: 'move'
+				cursor: 'move',
+				cancel: 'input,textarea,button,select,option,.CodeMirror'
 			});
 		}
 	};


### PR DESCRIPTION
Fixes #1299.

## Description
See #1299 for more details.

## Risk Level
Low.

## Testing procedure
1. Clear browser cache if necessary
1. Follow the steps outlined in #1299 to create a repeatable `textarea_code` field
1. Click and drag to try to select text in the CodeMirror area. The whole block should **not** drag

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).