### PR TITLE
Add "taxonomy_select_hierarchical" in CMB2_Sanitize->default_sanitization()

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -86,6 +86,7 @@ class CMB2_Sanitize {
 				$sanitized_value = $this->textarea();
 				break;
 			case 'taxonomy_select':
+			case 'taxonomy_select_hierarchical':
 			case 'taxonomy_radio':
 			case 'taxonomy_radio_inline':
 			case 'taxonomy_radio_hierarchical':


### PR DESCRIPTION
The new field type "taxonomy_select_hierarchical" did not save the data to the right table.

## Description
I have added a line of code into CMB2_Sanitize->default_sanitization() in order to save the taxonomy_* in to right table.

## Motivation and Context
When I tried to work on this new field type, it did not save the data into the right table, it suppose to update  the table _term_relationships instead it save the data into _postmeta

## Testing procedure
I have tested this code directly in my project. I have a list of custom_type taxonomies for a custom post_type. and with this modification it works as expected in my local, and prod environments.

NOTE: I have dowloaded the project from CMB2:develop branch.

