### PR TITLE
Add support for multiple attr for select input type

### DIFF
--- a/includes/types/CMB2_Type_Multi_Base.php
+++ b/includes/types/CMB2_Type_Multi_Base.php
@@ -99,11 +99,8 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 			// Check if this option is the value of the input
 			if ( $value === CMB2_Utils::normalize_if_numeric( $opt_value ) ) {
 				$a['checked'] = 'checked';
-			} else if ( is_array( $value) && in_array( $opt_value, $value ) ) {
+			} elseif ( is_array( $value) && in_array( CMB2_Utils::normalize_if_numeric( $opt_value ), $value, true ) ) {
 				// Check if this option is in the array of values of the input
-				$a['checked'] = 'checked';
-			} else if ( $value === $opt_value ) {
-				// Check if this option is the value of the input
 				$a['checked'] = 'checked';
 			}
 

--- a/includes/types/CMB2_Type_Multi_Base.php
+++ b/includes/types/CMB2_Type_Multi_Base.php
@@ -99,6 +99,12 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 			// Check if this option is the value of the input
 			if ( $value === CMB2_Utils::normalize_if_numeric( $opt_value ) ) {
 				$a['checked'] = 'checked';
+			} else if ( is_array( $value) && in_array( $opt_value, $value ) ) {
+				// Check if this option is in the array of values of the input
+				$a['checked'] = 'checked';
+			} else if ( $value === $opt_value ) {
+				// Check if this option is the value of the input
+				$a['checked'] = 'checked';
 			}
 
 			$concatenated_items .= $this->$method( $a, $i++ );


### PR DESCRIPTION
Props to @rubengc #995 

Didn't found this in a PR format so created this one.

Please advise.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for attribute multiple, showing correctly the multiple elements saved on database

## Motivation and Context
Motivation to provide CMB2 with the multiple feature out of box easily.
Fixes #995 

## Risk Level
admin-only

## Testing procedure
You can test by adding the 'multiple' attribute to a select field type
`$cmb->add_field( array( 'name' => 'Test Select', 'id' => 'wiki_test_select', 'type' => 'select', 'options' => array( 'standard' => __( 'Option One', 'cmb2' ), 'custom' => __( 'Option Two', 'cmb2' ), 'none' => __( 'Option Three', 'cmb2' ), ), 'attributes' => array( 'multiple' => true ) ) );`

## Types of changes
**Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).


