### PR TITLE
Add support for attribute multiple fixing name[]

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -586,14 +586,14 @@ class CMB2_Utils {
 		$attr_exclude[] = 'js_dependencies';
 
 		$attributes = '';
-		$is_multiple = in_array('multiple', $attrs, true);
+		$is_multiple = in_array( 'multiple', $attrs, true );
 		foreach ( $attrs as $attr => $val ) {
 			$excluded = in_array( $attr, (array) $attr_exclude, true );
 			$empty    = false === $val && 'value' !== $attr;
 			if ( ! $excluded && ! $empty ) {
 				// if data attribute, use single quote wraps, else double.
 				$quotes = self::is_data_attribute( $attr ) ? "'" : '"';
-				$val = ( $is_multiple === true && $attr === 'name' && substr($val, -2) !== '[]' ) ? $val . '[]' : $val;
+				$val = ( $attr === 'name' && substr( $val, -2 ) !== '[]' ) ? $val . '[]' : $val;
 				$attributes .= sprintf( ' %1$s=%3$s%2$s%3$s', $attr, $val, $quotes );
 			}
 		}

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -586,12 +586,14 @@ class CMB2_Utils {
 		$attr_exclude[] = 'js_dependencies';
 
 		$attributes = '';
+		$is_multiple = in_array('multiple', $attrs, true);
 		foreach ( $attrs as $attr => $val ) {
 			$excluded = in_array( $attr, (array) $attr_exclude, true );
 			$empty    = false === $val && 'value' !== $attr;
 			if ( ! $excluded && ! $empty ) {
 				// if data attribute, use single quote wraps, else double.
 				$quotes = self::is_data_attribute( $attr ) ? "'" : '"';
+				$val = ( $is_multiple === true && $attr === 'name' && substr($val, -2) !== '[]' ) ? $val . '[]' : $val;
 				$attributes .= sprintf( ' %1$s=%3$s%2$s%3$s', $attr, $val, $quotes );
 			}
 		}


### PR DESCRIPTION
Props to @rubengc #995 

Complements #1312 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for multiple attribute fixing the name adding [] when there isn't already defined.

## Motivation and Context
Motivation to provide CMB2 with the multiple feature out of box easily.
Fixes #995 

## Risk Level
admin-only

## Testing procedure
You can test by adding the 'multiple' attribute to a select field type
`$cmb->add_field( array( 'name' => 'Test Select', 'id' => 'wiki_test_select', 'type' => 'select', 'options' => array( 'standard' => __( 'Option One', 'cmb2' ), 'custom' => __( 'Option Two', 'cmb2' ), 'none' => __( 'Option Three', 'cmb2' ), ), 'attributes' => array( 'multiple' => true ) ) );`

## Types of changes
**Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).