### PR TITLE
Textarea_code Gutenberg compatibility and repeater fixes.

### DIFF
--- a/includes/CMB2_JS.php
+++ b/includes/CMB2_JS.php
@@ -241,12 +241,12 @@ class CMB2_JS {
 		);
 
 		if ( isset( self::$dependencies['code-editor'] ) && function_exists( 'wp_enqueue_code_editor' ) ) {
-			$l10n['defaults']['code_editor'] = wp_enqueue_code_editor( [
+			$l10n['defaults']['code_editor'] = wp_enqueue_code_editor( array(
 				'type'       => 'php',
 				'codemirror' => [
 					'autoRefresh' => true,
 				],
-			] );
+			) );
 		}
 
 		wp_localize_script( self::$handle, self::$js_variable, apply_filters( 'cmb2_localized_data', $l10n ) );

--- a/includes/CMB2_JS.php
+++ b/includes/CMB2_JS.php
@@ -241,9 +241,12 @@ class CMB2_JS {
 		);
 
 		if ( isset( self::$dependencies['code-editor'] ) && function_exists( 'wp_enqueue_code_editor' ) ) {
-			$l10n['defaults']['code_editor'] = wp_enqueue_code_editor( array(
-				'type' => 'text/html',
-			) );
+			$l10n['defaults']['code_editor'] = wp_enqueue_code_editor( [
+				'type'       => 'php',
+				'codemirror' => [
+					'autoRefresh' => true,
+				],
+			] );
 		}
 
 		wp_localize_script( self::$handle, self::$js_variable, apply_filters( 'cmb2_localized_data', $l10n ) );

--- a/includes/types/CMB2_Type_Textarea_Code.php
+++ b/includes/types/CMB2_Type_Textarea_Code.php
@@ -23,6 +23,7 @@ class CMB2_Type_Textarea_Code extends CMB2_Type_Textarea {
 		$args = wp_parse_args( $args, array(
 			'class' => 'cmb2-textarea-code',
 			'desc'  => '</pre>' . $this->_desc( true ),
+			'id'    => str_replace( '/', '__', $this->_id() )
 		) );
 
 		if ( true !== $this->field->options( 'disable_codemirror' )

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -990,10 +990,19 @@ window.CMB2 = window.CMB2 || {};
 		}
 
 		$selector.each( function() {
-			wp.codeEditor.initialize(
+			var instance = wp.codeEditor.initialize(
 				this.id,
 				cmb.codeEditorArgs( $( this ).data( 'codeeditor' ) )
 			);
+
+			// Update the textarea before Gutenberg saves the meta box.
+			if ( wp && wp.data && wp.data.subscribe ) {
+				wp.data.subscribe( function() {
+					if ( wp.data.select('core/edit-post').isSavingMetaBoxes() ) {
+						instance.codemirror.save();
+					}
+				})
+			}
 		} );
 	};
 

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -797,7 +797,7 @@ window.CMB2 = window.CMB2 || {};
 			if ( $element.hasClass('cmb2-media-status') ) {
 				// special case for image previews
 				val = $element.html();
-			} else if ( $element.hasClass('cmb2-textarea-code') ) {
+			} else if ( $element.hasClass( 'cmb2-textarea-code' ) && ! $element.hasClass( 'disable-codemirror' ) ) {
 				// Special case for codemirror.
 				val = cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.getValue();
 			} else if ( 'checkbox' === elType || 'radio' === elType ) {
@@ -838,7 +838,7 @@ window.CMB2 = window.CMB2 || {};
 				});
 			}
 			// Handle codemirror swapping.
-			else if ( $element.hasClass('cmb2-textarea-code') ) {
+			else if ( $element.hasClass( 'cmb2-textarea-code' ) && ! $element.hasClass( 'disable-codemirror' ) ) {
 				val = cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.getValue();
 				cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.setValue(  cmb.codeMirrorInstances[ inputVals[ index ].$.attr('id') ].codemirror.getValue() );
 				cmb.codeMirrorInstances[ inputVals[ index ].$.attr('id') ].codemirror.setValue( val );

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -508,6 +508,8 @@ window.CMB2 = window.CMB2 || {};
 		$elements.filter( ':selected' ).removeAttr( 'selected' );
 		$elements.find( ':selected' ).removeAttr( 'selected', false );
 
+		$row.find('.CodeMirror-wrap').remove();
+
 		if ( $row.find('h3.cmb-group-title').length ) {
 			$row.find( 'h3.cmb-group-title' ).text( $row.data( 'title' ).replace( '{#}', ( cmb.idNumber + 1 ) ) );
 		}
@@ -609,6 +611,9 @@ window.CMB2 = window.CMB2 || {};
 	cmb.afterRowInsert = function( $row ) {
 		// Init pickers from new row
 		cmb.initPickers( $row.find('input[type="text"].cmb2-timepicker'), $row.find('input[type="text"].cmb2-datepicker'), $row.find('input[type="text"].cmb2-colorpicker') );
+
+		// Init code editor for new row
+		cmb.initCodeEditors( $row.find('.cmb2-textarea-code:not(.disable-codemirror)') );
 	};
 
 	cmb.updateNameAttr = function () {

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -797,6 +797,9 @@ window.CMB2 = window.CMB2 || {};
 			if ( $element.hasClass('cmb2-media-status') ) {
 				// special case for image previews
 				val = $element.html();
+			} else if ( $element.hasClass('cmb2-textarea-code') ) {
+				// Special case for codemirror.
+				val = cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.getValue();
 			} else if ( 'checkbox' === elType || 'radio' === elType ) {
 				val = $element.is(':checked');
 			} else if ( 'select' === $element.prop('tagName') ) {
@@ -833,7 +836,12 @@ window.CMB2 = window.CMB2 || {};
 					name = name.replace('['+fromRowId+']', '['+toRowId+']');
 					$( this ).attr('name', name);
 				});
-
+			}
+			// Handle codemirror swapping.
+			else if ( $element.hasClass('cmb2-textarea-code') ) {
+				val = cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.getValue();
+				cmb.codeMirrorInstances[ $element.attr('id') ].codemirror.setValue(  cmb.codeMirrorInstances[ inputVals[ index ].$.attr('id') ].codemirror.getValue() );
+				cmb.codeMirrorInstances[ inputVals[ index ].$.attr('id') ].codemirror.setValue( val );
 			}
 			// handle checkbox swapping
 			else if ( 'checkbox' === elType  ) {
@@ -987,6 +995,8 @@ window.CMB2 = window.CMB2 || {};
 		}
 	};
 
+	cmb.codeMirrorInstances = {};
+
 	cmb.initCodeEditors = function( $selector ) {
 		cmb.trigger( 'cmb_init_code_editors', $selector );
 
@@ -999,6 +1009,7 @@ window.CMB2 = window.CMB2 || {};
 				this.id,
 				cmb.codeEditorArgs( $( this ).data( 'codeeditor' ) )
 			);
+			cmb.codeMirrorInstances[ this.id ] = instance;
 
 			// Update the textarea before Gutenberg saves the meta box.
 			if ( wp && wp.data && wp.data.subscribe ) {


### PR DESCRIPTION
## Description

General once over of the `textarea_code` field to fix all logged issues as well as a couple of unlogged limitations.

1. Fixes #571 
2. Fixes #1194 
3. Support fields with "/" in the name.
4. Fix field styling and saving with Gutenberg is active.

