### PR TITLE
Validate composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
 
 matrix:
   include:
+    - php: 7.1
+      script: composer validate --strict
+      after_script: ls -l composer.*
     - php: nightly
       env:
         - WP_VERSION=latest


### PR DESCRIPTION
As cmb2 is [published on packagist](https://packagist.org/packages/cmb2/cmb2) we must have a valid composer.json file.