### PR TITLE
Ensure to enqueue wp-color-picker

### DIFF
--- a/includes/CMB2_JS.php
+++ b/includes/CMB2_JS.php
@@ -90,6 +90,11 @@ class CMB2_JS {
 				self::colorpicker_frontend();
 			}
 
+			// Enqueue colorpicker
+			if ( ! wp_script_is( 'wp-color-picker', 'enqueued' ) ) {
+				wp_enqueue_script( 'wp-color-picker' );
+			}
+
 			if ( isset( $dependencies['wp-color-picker-alpha'] ) ) {
 				self::register_colorpicker_alpha();
 			}


### PR DESCRIPTION
For some reason, WordPress stops to enqueue wp-color-picker by default on post edit screens

This PR adds an extra check to enqueue wp-color-picker if hasn't enqueued yet

Fixes #1338