### PR TITLE
Travis update php v. 5.2-5.3-5.4 to wp max version 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,15 @@ matrix:
       env: WP_VERSION=3.8
     # Remove 5.3 or Travis build becomes too large.
     # - php: 7.1
-    #   env: WP_VERSION=latest SWITCH_TO_PHP=5.3
+    #   env: WP_VERSION=5.1 SWITCH_TO_PHP=5.3
     # - php: 7.1
     #   env: WP_VERSION=3.8 SWITCH_TO_PHP=5.3
     - php: 7.1
-      env: WP_VERSION=latest SWITCH_TO_PHP=5.2
+      env: WP_VERSION=5.1 SWITCH_TO_PHP=5.2
     - php: 7.1
       env: WP_VERSION=3.8 SWITCH_TO_PHP=5.2
     - php: 5.4
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1
     - php: 5.4
       env: WP_VERSION=3.8
   fast_finish: true


### PR DESCRIPTION
 Minimum PHP version increased to 5.6.20 as of WordPress 5.2



