### PR TITLE
Fix test for wysiwyg field with WP<5.3

### DIFF
--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -385,7 +385,7 @@ class Test_CMB2_Types extends Test_CMB2_Types_Base {
 		$this->assertHTMLstringsAreEqual(
 			'
 			<div id="wp-field_test_field-wrap" class="wp-core-ui wp-editor-wrap html-active">
-				<link rel=\'stylesheet\' id=\'dashicons-css\' href=\'' . includes_url( "css/dashicons$suffix.css?$version" ) . '\' media=\'all\' />
+				<link rel=\'stylesheet\' id=\'dashicons-css\' href=\'' . includes_url( "css/dashicons$suffix.css?$version" ) . '\' ' . $type_attr . 'media=\'all\' />
 				<link rel=\'stylesheet\' id=\'editor-buttons-css\' href=\'' . includes_url( "css/editor$suffix.css?$version" ) . '\' ' . $type_attr . 'media=\'all\' />
 				<div id="wp-field_test_field-editor-container" class="wp-editor-container">
 					<textarea class="wp-editor-area" rows="20" cols="40" name="field_test_field" id="field_test_field">

--- a/tests/test-cmb-types.php
+++ b/tests/test-cmb-types.php
@@ -381,7 +381,7 @@ class Test_CMB2_Types extends Test_CMB2_Types_Base {
 		) );
 		$type = $this->get_field_type_object( $field );
 
-		$type_attr = function_exists( 'current_theme_supports' ) && current_theme_supports( 'html5', 'style' ) ? "type='text/css' " : '';
+		$type_attr = version_compare( $version, '5.3', '<' ) ? "type='text/css' " : '';
 		$this->assertHTMLstringsAreEqual(
 			'
 			<div id="wp-field_test_field-wrap" class="wp-core-ui wp-editor-wrap html-active">


### PR DESCRIPTION
## Description
Use WP version instead of `current_theme_supports( 'html5', 'style' )`, to state if `Test_CMB2_Types::test_wysiwyg_field` should expect a rendered HTML string containing or not the attribute `type='text/css'`.

## Motivation and Context
`Test_CMB2_Types::test_wysiwyg_field` is currently failing for the builds with WP=3.8.

These [PHP=5.6 builds](https://travis-ci.org/github/navigatrum/CMB2/builds/694741818) and [PHP=5.4 builds](https://travis-ci.org/github/navigatrum/CMB2/builds/694792873) for all the WP versions, clearly suggest the tests are always failing with WP<5.3. I.e. `current_theme_supports( 'html5', 'style' )` is always false for the tested themes, but only with WP>=5.3 the rendered HTML string doesn't contain the attribute `type='text/css'`.

[This commit](https://github.com/CMB2/CMB2/commit/c4ac04db61485fcf3d693ece4244779da4a3a3c1#diff-148275844df7cd03afa4672b4b97ed76) forgot to use `$type_attr` for both the stylesheets. I [tested](https://travis-ci.org/github/navigatrum/CMB2/builds/694820529) a [commit](https://github.com/navigatrum/CMB2/commit/78db63a44a162a0e0e3991a78303c9367158ebb5) containing such integration, but it doesn't work.

So the problem depends on something changed in WP=5.3. 

#### Edit ####
Fixed typo.
