### PR TITLE
Fix WYSIWYG filed not working in a group

### DIFF
--- a/includes/types/CMB2_Type_Wysiwyg.php
+++ b/includes/types/CMB2_Type_Wysiwyg.php
@@ -46,7 +46,7 @@ class CMB2_Type_Wysiwyg extends CMB2_Type_Textarea {
 		$this->field->args['char_counter'] = false;
 
 		// wysiwyg fields in a group need some special handling.
-		$field->add_js_dependencies( 'wp-util', 'cmb2-wysiwyg' );
+		$field->add_js_dependencies( array( 'wp-util', 'cmb2-wysiwyg' ) );
 
 		// Hook in our template-output to the footer.
 		add_action( is_admin() ? 'admin_footer' : 'wp_footer', array( $this, 'add_wysiwyg_template_for_group' ) );


### PR DESCRIPTION
This PR fixes an issue where the WYSIWYG field isn't working in a group.

## Description
When refactoring the WYSIWYG field in https://github.com/CMB2/CMB2/commit/7bb887c8fc89cb76570433b436e3d6ca914ebcf9#diff-73510adb75ef05f23da2023345b5cf0dR49 the issue was introduced. `'wp-util', 'cmb2-wysiwyg'` should be `array( 'wp-util', 'cmb2-wysiwyg' )`.

## Motivation and Context
I use the wysiwyg field in a group and just noticed it stopped working, while it was working before.

## Risk Level
I think the risk level should be low.

## Testing procedure
Add a wysiwyg field to a group, it'll be displayed as a textarea, tinyMCE isn't initiated on it.

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

