### PR TITLE
FIX(colorpicker rgba) :: using rgba color picker for wordpress 5.5

### DIFF
--- a/includes/CMB2_JS.php
+++ b/includes/CMB2_JS.php
@@ -149,6 +149,14 @@ class CMB2_JS {
 		$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 		$func = $enqueue ? 'wp_enqueue_script' : 'wp_register_script';
 		$func( 'wp-color-picker-alpha', CMB2_Utils::url( "js/wp-color-picker-alpha{$min}.js" ), array( 'wp-color-picker' ), '2.1.3' );
+        wp_localize_script( 'wp-color-picker-alpha', 'wpColorPickerL10n', array(
+            'clear'            => __( 'Clear', 'cmb2'  ),
+            'clearAriaLabel'   => __( 'Clear color', 'cmb2'  ),
+            'defaultString'    => __( 'Default', 'cmb2'  ),
+            'defaultAriaLabel' => __( 'Select default color', 'cmb2'  ),
+            'pick'             => __( 'Select Color', 'cmb2'  ),
+            'defaultLabel'     => __( 'Color value', 'cmb2'  ),
+        ) );
 	}
 
 	/**


### PR DESCRIPTION
we can not use rgba color picker in wordpress 5.5, because of console error.

Uncaught ReferenceError: wpColorPickerL10n is not defined

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
in wordpress 5.5 we can not use rgba color picker because js variable is not defined :
Uncaught ReferenceError: wpColorPickerL10n is not defined
this variable is deleted is wordpress 5.5 and we added it in cmb2
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
because we can not use rgba colorpicker in wordpress 5.5
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #{issue-number}.
https://github.com/CMB2/CMB2/issues/1373
https://github.com/CMB2/CMB2/issues/1368
## Risk Level
<!--- Document the potential risks for this PR, -->
<!--- E.g. admin-only = minimal risk, or major user feature = high risk -->
admin-only = minimal risk
## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test it in wordpress 5.5
## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

- [x] My code follows the code style of this project.

