### PR TITLE
Update CMB2_Options_Hookup.php

### DIFF
--- a/includes/CMB2_Options_Hookup.php
+++ b/includes/CMB2_Options_Hookup.php
@@ -67,8 +67,24 @@ class CMB2_Options_Hookup extends CMB2_Hookup {
 		// Optionally network_admin_menu.
 		$hook = $this->cmb->prop( 'admin_menu_hook' );
 
-		// Hook in to add our menu.
-		add_action( $hook, array( $this, 'options_page_menu_hooks' ) );
+		$parent_slug = $this->cmb->prop( 'parent_slug' );
+		$position    = $this->cmb->prop( 'position' );
+
+		if ( $parent_slug ) { 				
+			// Hook in to add our sub_menu.
+			if ( $position > 0 ){
+				// Hook in to add our sub_menu setting position
+				add_action( $hook, array( $this, 'options_page_menu_hooks' ), 100 * $position );
+			}
+			else { 				
+				// Hook in to add our sub_menu in a very last position
+				add_action( $hook, array( $this, 'options_page_menu_hooks' ), 2000 );
+			}
+		}
+		else{
+			// Hook in to add our menu.
+			add_action( $hook, array( $this, 'options_page_menu_hooks' ) );
+		}
 
 		// If in the network admin, need to use get/update_site_option.
 		if ( 'network_admin_menu' === $hook ) {


### PR DESCRIPTION
With this changes, the order of the menu options work fine.

<!--- Provide a general summary of your changes in the Title above -->

## Description
If position is indicated, we assign the indicated position multiplied by 100, and if it is not indicated we assign the value 2000 that places it at the end of the list.

## Motivation and Context
With this changes, the order of the menu options work fine.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1380.

## Risk Level
<!--- Document the potential risks for this PR, -->
<!--- E.g. admin-only = minimal risk, or major user feature = high risk -->

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
I create diferent menus, and change the position value, and see the position is set correct.
I think  this changes do not affect aother areas of the code.

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

## Screenshots
<!--- Provide screenshots if possible -->

