### PR TITLE
move $args in deprecated_param method for PHP 7.4

### DIFF
--- a/includes/CMB2_Base.php
+++ b/includes/CMB2_Base.php
@@ -413,8 +413,9 @@ abstract class CMB2_Base {
 	 */
 	protected function deprecated_param( $function, $version, $message = null ) {
 
+		$args = func_get_args();
+
 		if ( is_numeric( $message ) ) {
-			$args = func_get_args();
 
 			switch ( $message ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In `/includes/CMB2_Base.php`, in the `deprecated_param` method, `$args = func_get_args();` is currently inside the `is_numeric` if statement. This change moves it to the beginning of `deprecated_param` instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1389. PHP 7.4 raises a warning without this change.

## Risk Level
<!--- Document the potential risks for this PR, -->
<!--- E.g. admin-only = minimal risk, or major user feature = high risk -->

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this on the `develop` branch of CMB2. I added a new field, using the `default` param instead of `default_cb` to raise the deprecated warning. It raises this log message:

```php
[05-Jan-2021 18:52:51 UTC] PHP Notice:  CMB2_Field::__construct() was called with a parameter that is <strong>deprecated</strong> since version 2.2.3! Using the "default" field parameter as a callback has been deprecated in favor of the "default_cb" parameter. in /vanilla-wordpress/wp-content/plugins/cmb2/includes/CMB2_Base.php on line 457
```

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
