### PR TITLE
Sanitize URLs with HTTPS

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -178,6 +178,30 @@ class CMB2_Sanitize {
 	}
 
 	/**
+	 * Sanitize a URL. Make the default scheme HTTPS.
+	 *
+	 * @since  X.X.X
+	 * @param  string  $value     Unescaped URL.
+	 * @param  array   $protocols Allowed protocols for URL
+	 * @param  string  $default   Default value if no URL found.
+	 * @return string             escaped URL
+	 */
+	public function sanitize_and_secure_url( $url, $protocols, $default ) {
+		if ( ! $url ) {
+			return $default;
+		}
+
+		$safe_url = esc_url_raw( $url, $protocols );
+
+		// If we are adding a HTTP protocol, make it HTTPS instead.
+		if ( NULL === parse_url( $url, PHP_URL_SCHEME ) ) {
+			$safe_url = set_url_scheme( $safe_url, 'https' );
+		}
+
+		return $safe_url;
+	}
+
+	/**
 	 * Validate url in a meta value.
 	 *
 	 * @since  1.0.1
@@ -185,13 +209,14 @@ class CMB2_Sanitize {
 	 */
 	public function text_url() {
 		$protocols = $this->field->args( 'protocols' );
+		$default   = $this->field->get_default();
 		// for repeatable.
 		if ( is_array( $this->value ) ) {
 			foreach ( $this->value as $key => $val ) {
-				$this->value[ $key ] = $val ? esc_url_raw( $val, $protocols ) : $this->field->get_default();
+				$this->value[ $key ] = self::sanitize_and_secure_url( $val, $protocols, $default );
 			}
 		} else {
-			$this->value = $this->value ? esc_url_raw( $this->value, $protocols ) : $this->field->get_default();
+			$this->value = self::sanitize_and_secure_url( $this->value, $protocols, $default );
 		}
 
 		return $this->value;


### PR DESCRIPTION
## Description
URLs without a scheme now get HTTPS as the default, not HTTP.

## Motivation and Context
Avoids information disclosure / malicious redirection.
Fixes #1412.

## Risk Level
minimal risk

## Testing procedure
Tested by passing in URLs with no scheme, http: and https:

## Checklist:
- [X] My code follows the code style of this project.
- [X] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).
