### PR TITLE
add flat_options_list parameter

### DIFF
--- a/includes/types/CMB2_Type_Multi_Base.php
+++ b/includes/types/CMB2_Type_Multi_Base.php
@@ -93,11 +93,12 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 			// Clone args & modify for just this item
 			$a = $args;
 
-			$a['value'] = $opt_value;
-			$a['label'] = $opt_label;
+			// If flat_options_list is true, use the label as both value and label.
+			$field_value = isset( $args['flat_options_list'] ) && $args['flat_options_list'] ? $opt_label : $opt_value;
+			$a['label']  = $opt_label;
 
 			// Check if this option is the value of the input
-			if ( $value === CMB2_Utils::normalize_if_numeric( $opt_value ) ) {
+			if ( $value === CMB2_Utils::normalize_if_numeric( field_value ) ) {
 				$a['checked'] = 'checked';
 			}
 

--- a/includes/types/CMB2_Type_Select.php
+++ b/includes/types/CMB2_Type_Select.php
@@ -18,7 +18,7 @@ class CMB2_Type_Select extends CMB2_Type_Multi_Base {
 			'name'    => $this->_name(),
 			'id'      => $this->_id(),
 			'desc'    => $this->_desc( true ),
-			'options' => $this->concat_items(),
+			'options' => $this->concat_items( [ 'flat_options_list' => ! empty( $this->field->args['flat_options_list'] ) ] ),
 		) );
 
 		$attrs = $this->concat_attrs( $a, array( 'desc', 'options' ) );


### PR DESCRIPTION
## Description
Adds a `flat_options_list` parameter. Allows `options` to take arrays (i.e. `['red', 'green', 'blue' ]`) as lists without declaring duplicate keys and values (`['red' => 'red', 'green' => 'green', 'blue' => 'blue' ]`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1411.

## Risk Level
<!--- Document the potential risks for this PR, -->
<!--- E.g. admin-only = minimal risk, or major user feature = high risk -->
Minimal risk. Does not change default behaviour.

## Testing procedure
Have performed manual testing. May require additional unit tests. Will require documentation update.

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **New feature (non-breaking change which adds functionality)**

## Checklist:
- [X] My code follows the code style of this project.
- [X] My code and pull requests meets the [Contributing guidelines]