### PR TITLE
Gather group field values before render for use in group_title_cb

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -614,25 +614,31 @@ class CMB2 extends CMB2_Base {
 			echo '<button type="button" data-selector="', $field_group->id(), '_repeat" data-confirm="', esc_attr( $confirm_deletion ), '" class="dashicons-before dashicons-no-alt cmb-remove-group-row" title="', esc_attr( $field_group->options( 'remove_button' ) ), '"></button>';
 		}
 
-			echo '
-			<div class="cmbhandle" title="' , esc_attr__( 'Click to toggle', 'cmb2' ), '"><br></div>
-			<h3 class="cmb-group-title cmbhandle-title"><span>', $field_group->replace_hash( $field_group->options( 'group_title' ) ), '</span></h3>
-
-			<div class="inside cmb-td cmb-nested cmb-field-list">';
-				// Loop and render repeatable group fields.
+		// Gather field values for group_title replacements.
+		$fields       = [];
+		$field_values = [];
 		foreach ( array_values( $field_group->args( 'fields' ) ) as $field_args ) {
 			if ( 'hidden' === $field_args['type'] ) {
-
 				// Save rendering for after the metabox.
 				$this->add_hidden_field( $field_args, $field_group );
-
 			} else {
-
 				$field_args['show_names'] = $field_group->args( 'show_names' );
 				$field_args['context']    = $field_group->args( 'context' );
-
-				$this->get_field( $field_args, $field_group )->render_field();
+				$field = $this->get_field( $field_args, $field_group );
+				$field_values[ $field->id( true ) ] = $field->value();
+				$fields[ $field->id() ] = $field;
 			}
+		}
+
+		$group_title = $field_group->replace_hash( $field_group->options( 'group_title' ), $field_values );
+			echo '
+			<div class="cmbhandle" title="' , esc_attr__( 'Click to toggle', 'cmb2' ), '"><br></div>
+			<h3 class="cmb-group-title cmbhandle-title"><span>', $group_title, '</span></h3>
+
+			<div class="inside cmb-td cmb-nested cmb-field-list">';
+		// Loop and render repeatable group fields.
+		foreach ( $fields as $field ) {
+			$field->render_field();
 		}
 
 		if ( $field_group->args( 'repeatable' ) ) {

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1170,12 +1170,18 @@ class CMB2_Field extends CMB2_Base {
 	 * Replaces a hash key - {#} - with the repeatable index
 	 *
 	 * @since  1.2.0
-	 * @param  string $value Value to update.
+	 * @param string $value       Value to update.
+	 * @param array $replacements Replacement key value pairs.
+	 *
 	 * @return string        Updated value
 	 */
-	public function replace_hash( $value ) {
+	public function replace_hash( $value, $replacements = [] ) {
 		// Replace hash with 1 based count.
-		return str_replace( '{#}', ( $this->index + 1 ), $value );
+		$result = str_replace( '{#}', ( $this->index + 1 ), $value );
+		foreach ( $replacements as $search => $replace ) {
+			$result = str_replace( "{#$search}", $replace, $result );
+		}
+		return $result;
 	}
 
 	/**

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -80,8 +80,8 @@ window.CMB2 = window.CMB2 || {};
 			.on( 'click', '.cmb-remove-row-button', cmb.removeAjaxRow )
 			// Ajax oEmbed display
 			.on( 'keyup paste focusout', '.cmb2-oembed', cmb.maybeOembed )
-			// Reset titles when removing a row
-			.on( 'cmb2_remove_row', '.cmb-repeatable-group', cmb.resetTitlesAndIterator )
+			// Reset titles when adding, removing, and shifting rows
+			.on( 'cmb2_add_row cmb2_remove_row cmb2_shift_rows_complete', cmb.updateGroupRowTitles )
 			.on( 'click', '.cmbhandle, .cmbhandle + .cmbhandle-title', cmb.toggleHandle );
 
 		if ( $repeatGroup.length ) {
@@ -181,29 +181,38 @@ window.CMB2 = window.CMB2 || {};
 		});
 	};
 
-	cmb.resetTitlesAndIterator = function( evt ) {
-		if ( ! evt.group ) {
-			return;
-		}
+	/**
+	 * Update all group row titles with token replacements.
+	 */
+	cmb.updateGroupRowTitles = function() {
+		var $metabox = cmb.metabox()
 
 		// Loop repeatable group tables
-		$( '.cmb-repeatable-group.repeatable' ).each( function() {
+		$metabox.find( '.cmb-repeatable-group.repeatable' ).each( function() {
 			var $table = $( this );
-			var groupTitle = $table.find( '.cmb-add-group-row' ).data( 'grouptitle' );
 
 			// Loop repeatable group table rows
 			$table.find( '.cmb-repeatable-grouping' ).each( function( rowindex ) {
+				var groupTitle = $table.find( '.cmb-add-group-row' ).data( 'grouptitle' );
 				var $row = $( this );
 				var $rowTitle = $row.find( 'h3.cmb-group-title' );
 				// Reset rows iterator
 				$row.data( 'iterator', rowindex );
 				// Reset rows title
 				if ( $rowTitle.length ) {
-					$rowTitle.text( groupTitle.replace( '{#}', ( rowindex + 1 ) ) );
+					groupTitle = groupTitle.replace( '{#}', ( rowindex + 1 ) )
+					$row.find( 'input,select' ).each( function() {
+						var $element = $( this );
+						var fieldIdRaw = $element.attr( 'name' ).replace( /]/g, '' ).split( '[' ).pop();
+						if ( fieldIdRaw ) {
+							groupTitle = groupTitle.replace( '{#' + fieldIdRaw + '}', $element.val() )
+						}
+					} );
+					$rowTitle.text( groupTitle );
 				}
 			});
 		});
-	};
+	}
 
 	cmb.toggleHandle = function( evt ) {
 		evt.preventDefault();


### PR DESCRIPTION
This PR adds simple field values as possible replacement tokens within a group row title.

## Description

I looked around the project a bit to gather some thoughts on this one. Resources used:

* https://github.com/CMB2/CMB2-Snippet-Library/blob/master/javascript/dynamically-change-group-field-title-from-subfield.php -- Snippet for dynamically changing titles - Used this as a reference for js events to subscribe to
* Reviewed existing opened and closed PRs about group titles

#### Code changes

1. In `render_group_row()`, there is a new loop over the fields before the group title is output so that the field values can be gathered and passed into `CMB2_Field::replace_hash()`.
2. In `CMB2_Field::replace_hash()`, there is a new array parameter that accepts additional replacements. The function now loops through those values and performs a `str_replace` using the existing `{#}` token as a pattern. For example, if a key in the replacements array is `'my_title'` and the value is `Great Title`, the function will replace `{#my_title}` with the value.
3. In the javascript there is a new function that adjusts group row titles when rows are added, removed, or shifted. It gets the values for the replacements from simple fields (inputs and select boxes).

#### Thoughts

* This js approach doesn't subcribe to keyup events to dynamically update the row titles. I think it's reasonable that the field group title isn't that-dynamic, and I worried about causing slowness in situations where there may be hundreds of fields on the page. If someone wants their fields to update on keyup, they should be able to do so in their plugin's js.
* The js only performs replacements of the most simple fields, input and select boxes. My thought was that textarea content is likely too large and complex to ever represent in a group row title. There could be a future update to have the js handle more field types.

## Motivation and Context

This change allows group row titles to have much more useful information. In some cases a group row may have many fields that all work together to produce a complex result. This change allows group row titles to summarize the result of the group row easily.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #706 

## Risk Level
admin-only = Minimal. I tried to change as little as possible.

## Testing procedure

Create a field group with a few simple fields in it, and provide a `group_title` string that includes the new field ids as the replacement pattern `{#field_id}`. Save the group with values for multiple rows.

 Test:
 
* Add a row. expect: the group title will not include new values.
* Shift rows. expect: the group title for each row will be updated appropriately to reflect the values in the rows. If you add a row, provide values, then shift it, the new row title will show the row's values.
* Remove rows. expect: the group titles for each row will be updated appropriately to reflect the values in the remaining rows.

#### Snippet as option-page

```php
function yourprefix_register_repeatable_group_field_title_example() {

	/**
	 * Repeatable Field Groups
	 */
	$cmb_group = new_cmb2_box( array(
		'id'           => 'yourprefix_group_titles_metabox',
		'title'        => __( 'Repeating Field Group with Updating Titles', 'cmb2' ),
		'object_types' => array( 'options-page', ),
		'option_key'      => 'yourprefix_main_options',
		'show_in_rest' => 'read_and_write',
	) );

	$group_field_id = $cmb_group->add_field( array(
		'id'          => 'yourprefix_group_titles_demo',
		'type'        => 'group',
		'description' => __( 'Generates reusable form entries', 'cmb2' ),
		'options'     => array(
			// {#} gets replaced by row number
			// {#first_number} gets replaced with the value of the first_number field
			// {#operator} gets replaced with the value of the operator field
			// {#second_number} gets replaced with the value of the second_number field
			'group_title'    => __( 'Row: {#} - This row will test if: {#first_number} {#operator} {#second_number}', 'cmb2' ),
			'add_button'     => __( 'Add Another Entry', 'cmb2' ),
			'remove_button'  => __( 'Remove Entry', 'cmb2' ),
			'sortable'       => true, // beta
		),
		'after_group' => 'yourprefix_add_js_for_repeatable_titles',
	) );

	$cmb_group->add_group_field( $group_field_id, array(
		'name' => 'First number',
		'id'   => 'first_number',
		'type' => 'text',
	) );

	$cmb_group->add_group_field( $group_field_id, array(
		'name' => 'Operator',
		'id'   => 'operator',
		'type' => 'select',
		'options' => [
			'==' => 'Equals',
			'!=' => 'Does not equal',
			'>'  => 'Greater than',
			'<'  => 'Less than',
		],
	) );

	$cmb_group->add_group_field( $group_field_id, array(
		'name' => 'Second number',
		'id'   => 'second_number',
		'type' => 'text',
	) );
}
add_action( 'cmb2_init', 'yourprefix_register_repeatable_group_field_title_example' );
```


## Types of changes
- **New feature (non-breaking change which adds functionality)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.  (I think this is true, may have missed a space or something)
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

## Screenshots

![2021-05-17_08-37](https://user-images.githubusercontent.com/1205329/118489746-2f2d4d80-b6eb-11eb-94bc-7645de970248.png)


