### PR TITLE
Load styles on WooCommerce HPOS order page

### DIFF
--- a/includes/CMB2_Hookup.php
+++ b/includes/CMB2_Hookup.php
@@ -319,6 +319,7 @@ class CMB2_Hookup extends CMB2_Hookup_Base {
 			'user-new.php',
 			'profile.php',
 			'user-edit.php',
+			'woocommerce_page_wc-orders',
 		);
 		// only pre-enqueue our scripts/styles on the proper pages
 		// show_form_for_type will have us covered if we miss something here.


### PR DESCRIPTION
Add 'woocommerce_page_wc-orders' to $hooks array in do_scripts() so that CMB2 styles are loaded on WooCommerce Edit Order page when HPOS enabled.

<!--- Provide a general summary of your changes in the Title above -->

## Description
CMB2 styles are loaded on a number of admin pages but not the WooCommerce Edit Order page when HPOS is enabled. This page uses admin.php but adding that did not work so I added 'woocommerce_page_wc-orders' to the array.

## Motivation and Context
Related to adding a metabox on a WooCommerce Edit Order page when HPOS enabled.
https://wordpress.org/support/topic/how-do-i-show-metabox-on-woocommerce-order-page-for-hpos-setup/
and my code to add tracking info to a WooCommerce order email
https://www.damiencarbery.com/2020/01/add-tracking-info-to-woocommerce-order/

## Risk Level
admin-only, probably minimal risk.

## Testing procedure
I tested the code by loading the WooCommerce Edit Order page without and with the new line.
I am using WampServer 3.2.6 64bit on Windows 11.
WordPress 6.3, CMB2 2.10.1, WooCommerce 8.0.2

## Types of changes
- **Bug fix (non-breaking change which fixes an issue)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

## Screenshots
Before:
![regular-text-overspill](https://github.com/damiencarbery/CMB2/assets/5992651/1737244b-4bc5-471d-8c09-289611f52ed7)
After:
![cmb2-styles-loaded](https://github.com/damiencarbery/CMB2/assets/5992651/b4f40ebe-593f-4015-baa4-3891e539727a)
