### PR TITLE
add a phpcompatibility action

### DIFF
--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -8,8 +8,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check PHP Compatibility
+      - name: Check PHP 8.2
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
-          test-versions: 8.2-
+          test-versions: 8.2
           paths: '**/*.php'
+      - name: Check PHP 8.1
+        uses: pantheon-systems/phpcompatibility-action@v1
+        with:
+          test-versions: 8.1
+          paths: '**/*.php'
+      - name: Check PHP 8.0 and below
+        uses: pantheon-systems/phpcompatibility-action@v1
+        with:
+          test-versions: 8.0-
+          paths: '**/*.php'                    

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -12,4 +12,4 @@ jobs:
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
           test-versions: 8.2-
-          paths: ${{ github.workspace }}
+          paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/includes/*.php

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -8,18 +8,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check PHP 8.2
+      - name: Check PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
-          test-versions: 8.2
+          test-versions: '8.2-'
           paths: '**/*.php'
-      - name: Check PHP 8.1
-        uses: pantheon-systems/phpcompatibility-action@v1
-        with:
-          test-versions: 8.1
-          paths: '**/*.php'
-      - name: Check PHP 8.0 and below
-        uses: pantheon-systems/phpcompatibility-action@v1
-        with:
-          test-versions: 8.0-
-          paths: '**/*.php'                    

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -1,0 +1,15 @@
+name: PHP Compatibility
+on: [push]
+jobs:
+  phpcompat:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check PHP Compatibility
+        uses: pantheon-systems/phpcompatibility-action@v1
+        with:
+          test-versions: 8.0+
+          paths: ${{ github.workspace }}

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -12,4 +12,4 @@ jobs:
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
           test-versions: 8.2-
-          paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/includes/*.php
+          paths: '**/*.php'

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Check PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@v1
         with:
-          test-versions: 8.0+
+          test-versions: 8.2-
           paths: ${{ github.workspace }}


### PR DESCRIPTION
## Description
Adds a PHP Compatibility action to that validates against [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility)

## Motivation and Context
Should alert in the future if any change is not compatible with the latest PHP version. Will need to be updated for PHP 8.3, 8.4, 9.0, etc.

## Risk Level
minimal risk -- this only runs in the repository. The potential gain is big, though, because it should, in theory, catch any PHP compatibility issues.

I'm somewhat suspicious of the passing tests now, however, because it seems like they may be false positives, but with the action in place and set, issues can be reported to https://github.com/pantheon-systems/phpcompatibility-action/issues if it seems like we're not getting appropriate flagging.

## Testing procedure
Self-testing. This PR is, itself, a test. 😀 

## Types of changes
**New feature (GH action)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).


