### PR TITLE
use `dev` instead of `v1` for `phpcompatibility-action`

### DIFF
--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check PHP Compatibility
-        uses: pantheon-systems/phpcompatibility-action@v1
+        uses: pantheon-systems/phpcompatibility-action@dev
         with:
           test-versions: '8.2-'
           paths: '**/*.php'

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -2,10 +2,8 @@ name: PHP Compatibility
 on: [push]
 jobs:
   phpcompat:
+    name: PHP 8.x Compatibility Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php_version: [ '8.0', '8.1', '8.2' ]
 
     steps:
       - name: Checkout
@@ -14,5 +12,5 @@ jobs:
       - name: Check PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@dev
         with:
-          test-versions: '${{ matrix.php_version }}-'
+          test-versions: '8.0-'
           paths: '${{ github.workspace }}/**/*.php'

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -12,4 +12,4 @@ jobs:
         uses: pantheon-systems/phpcompatibility-action@dev
         with:
           test-versions: '8.2-'
-          paths: '**/*.php'
+          paths: '${{ github.workspace }}/**/*.php'

--- a/.github/workflows/phpcompat.yml
+++ b/.github/workflows/phpcompat.yml
@@ -3,6 +3,9 @@ on: [push]
 jobs:
   phpcompat:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php_version: [ '8.0', '8.1', '8.2' ]
 
     steps:
       - name: Checkout
@@ -11,5 +14,5 @@ jobs:
       - name: Check PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@dev
         with:
-          test-versions: '8.2-'
+          test-versions: '${{ matrix.php_version }}-'
           paths: '${{ github.workspace }}/**/*.php'


### PR DESCRIPTION
## Description
Uses the `dev` branch of the `phpcompatibility-action` rather than the `v1`

## Motivation and Context
`v1` uses the stable, 9.3 version of the PHPCompatibility sniffs, however that version does not include any 8.x checks, so running `8.x-` doesn't check anything valuable.

The `dev` branch of the action pulls the `develop` branch of PHPCompatibility, which _does_ include 8.x sniffs.

## Risk Level
minimal (although we should get errors for PHP 8.x compatibility)

## Testing procedure
Should be evident in the tests...

## Types of changes
- **New feature (non-breaking change which adds functionality)**

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).


