### PR TITLE
Avoid considering the value of default parameter as a callback in cmb2

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -1626,7 +1626,8 @@ class CMB2_Field extends CMB2_Base {
 		}
 
 		// default param can be passed a callback as well.
-		if ( is_callable( $args['default'] ) ) {
+		// but by making the default_cb value false, you can avoid checking the default value as callback!
+		if ( $args['default_cb'] !== false && is_callable( $args['default'] ) ) {
 
 			$this->deprecated_param( __CLASS__ . '::__construct()', '2.2.3', self::DEPRECATED_CB_PARAM, 'default', 'default_cb' );
 


### PR DESCRIPTION
Some string values considered for the default parameter may be identified as a callback, although they aren't actually callbacks. so these values can't be set as defaults. For example, if we set the `end` string to the `default` param of a `select` field, we will face problems. a deprecation message is displayed and the `end` string is considered as a callback.


## Solution

by setting the value `false` for the `default_cb` param, you can avoid checking the `default` value as a callback.