### PR TITLE
Update CMB2_Sanitize.php

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -431,7 +431,7 @@ class CMB2_Sanitize {
 	 * @return string       Sanitized data
 	 */
 	public function textarea() {
-		return is_array( $this->value ) ? array_map( 'wp_kses_post', $this->value ) : wp_kses_post( $this->value );
+		return is_array( $this->value ) ? array_map( 'wp_kses_post', $this->value ) : ( $this->value !== null ? wp_kses_post( $this->value ) : '' );
 	}
 
 	/**


### PR DESCRIPTION
return is_array( $this->value ) ? array_map( 'wp_kses_post', $this->value ) : wp_kses_post( $this->value );

Causes a PHP warning if a textarea field is not in $_REQUEST because it uses the "wp_kses_post" with a null value

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #{issue-number}.

## Risk Level
<!--- Document the potential risks for this PR, -->
<!--- E.g. admin-only = minimal risk, or major user feature = high risk -->

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Remove those that don't apply: -->
- **Bug fix (non-breaking change which fixes an issue)**
- **New feature (non-breaking change which adds functionality)**
- **Breaking change (fix or feature that would cause existing functionality to change)**

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My code and pull requests meets the [Contributing guidelines](https://github.com/CMB2/CMB2/blob/develop/CONTRIBUTING.md).

## Screenshots
<!--- Provide screenshots if possible -->

