### PR TITLE
Fix: sanitize field_id input and escape rel attribute in oEmbed handler

### DIFF
--- a/includes/CMB2_Ajax.php
+++ b/includes/CMB2_Ajax.php
@@ -91,7 +91,7 @@ class CMB2_Ajax {
 		// Get embed code (or fallback link).
 		$html = $this->get_oembed( array(
 			'url'         => $oembed_url,
-			'object_id'   => $_REQUEST['object_id'],
+			'object_id'   => isset( $_REQUEST['object_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['object_id'] ) ) : '',
 			'object_type' => isset( $_REQUEST['object_type'] ) ? $_REQUEST['object_type'] : 'post',
 			'oembed_args' => $embed_args,
 			'field_id'    => isset( $_REQUEST['field_id'] ) && is_string( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',

--- a/includes/CMB2_Ajax.php
+++ b/includes/CMB2_Ajax.php
@@ -94,7 +94,7 @@ class CMB2_Ajax {
 			'object_id'   => $_REQUEST['object_id'],
 			'object_type' => isset( $_REQUEST['object_type'] ) ? $_REQUEST['object_type'] : 'post',
 			'oembed_args' => $embed_args,
-			'field_id'    => isset( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',
+			'field_id'    => isset( $_REQUEST['field_id'] ) && is_string( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',
 		) );
 
 		wp_send_json_success( $html );

--- a/includes/CMB2_Ajax.php
+++ b/includes/CMB2_Ajax.php
@@ -68,7 +68,7 @@ class CMB2_Ajax {
 		}
 
 		// Sanitize our search string.
-		$oembed_string = sanitize_text_field( $_REQUEST['oembed_url'] );
+		$oembed_string = sanitize_text_field( wp_unslash( $_REQUEST['oembed_url'] ) );
 
 		// Send back error if empty.
 		if ( empty( $oembed_string ) ) {

--- a/includes/CMB2_Ajax.php
+++ b/includes/CMB2_Ajax.php
@@ -94,7 +94,7 @@ class CMB2_Ajax {
 			'object_id'   => $_REQUEST['object_id'],
 			'object_type' => isset( $_REQUEST['object_type'] ) ? $_REQUEST['object_type'] : 'post',
 			'oembed_args' => $embed_args,
-			'field_id'    => $_REQUEST['field_id'],
+			'field_id'    => isset( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',
 		) );
 
 		wp_send_json_success( $html );
@@ -178,7 +178,7 @@ class CMB2_Ajax {
 
 		// Send back our embed.
 		if ( $oembed['embed'] && $oembed['embed'] != $oembed['fallback'] ) {
-			return '<div class="cmb2-oembed embed-status">' . $oembed['embed'] . '<p class="cmb2-remove-wrapper"><a href="#" class="cmb2-remove-file-button" rel="' . $oembed['args']['field_id'] . '">' . esc_html__( 'Remove Embed', 'cmb2' ) . '</a></p></div>';
+			return '<div class="cmb2-oembed embed-status">' . $oembed['embed'] . '<p class="cmb2-remove-wrapper"><a href="#" class="cmb2-remove-file-button" rel="' . esc_attr( $oembed['args']['field_id'] ) . '">' . esc_html__( 'Remove Embed', 'cmb2' ) . '</a></p></div>';
 		}
 
 		// Otherwise, send back error info that no oEmbeds were found.

--- a/includes/CMB2_Ajax.php
+++ b/includes/CMB2_Ajax.php
@@ -94,7 +94,7 @@ class CMB2_Ajax {
 			'object_id'   => isset( $_REQUEST['object_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['object_id'] ) ) : '',
 			'object_type' => isset( $_REQUEST['object_type'] ) ? $_REQUEST['object_type'] : 'post',
 			'oembed_args' => $embed_args,
-			'field_id'    => isset( $_REQUEST['field_id'] ) && is_string( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',
+			'field_id'    => isset( $_REQUEST['field_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['field_id'] ) ) : '',
 		) );
 
 		wp_send_json_success( $html );

--- a/tests/test-cmb-ajax.php
+++ b/tests/test-cmb-ajax.php
@@ -201,6 +201,46 @@ class Test_CMB2_Ajax extends CMB2TestCase {
 	}
 
 	/**
+	 * A field_id submitted as an array (?field_id[]=x) must be handled safely.
+	 * WordPress's sanitize_text_field() returns '' for array/object input (and
+	 * wp_unslash() is array-safe), so sanitize_text_field( wp_unslash( array ) )
+	 * yields '' with no PHP error — no is_string() guard is required. This locks
+	 * that behavior so the guard is not reintroduced on a false TypeError premise.
+	 *
+	 * @group cmb2-ajax-embed
+	 */
+	public function test_oembed_handler_handles_array_field_id() {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', array( $this, 'throw_oembed_die_handler' ), 99 );
+
+		$_REQUEST['cmb2_ajax_nonce'] = wp_create_nonce( 'ajax_nonce' );
+		$_REQUEST['oembed_url']      = $this->oembed_args['url'];
+		$_REQUEST['object_id']       = 'options-page-id';
+		$_REQUEST['field_id']        = array( 'unexpected', 'array' ); // The odd input under test.
+
+		$reached_send_json = false;
+		$json              = '';
+
+		ob_start();
+		try {
+			cmb2_ajax()->oembed_handler();
+		} catch ( CMB2_Test_Oembed_Die $e ) {
+			$reached_send_json = true;
+			$json              = ob_get_contents();
+		} finally {
+			ob_end_clean();
+			unset( $_REQUEST['cmb2_ajax_nonce'], $_REQUEST['oembed_url'], $_REQUEST['object_id'], $_REQUEST['field_id'] );
+		}
+
+		$this->assertTrue( $reached_send_json, 'oembed_handler() should handle an array field_id without a PHP error.' );
+
+		$decoded = json_decode( $json, true );
+		$this->assertTrue( ! empty( $decoded['success'] ), 'Handler should return a successful JSON response.' );
+		// The array field_id collapses to '' and is escaped into an empty rel attribute.
+		$this->assertStringContainsString( 'rel=""', $decoded['data'] );
+	}
+
+	/**
 	 * Returns a wp_die handler (for the wp_die_ajax_handler filter) that throws a
 	 * marker exception, letting the test observe that wp_die() was reached.
 	 */

--- a/tests/test-cmb-ajax.php
+++ b/tests/test-cmb-ajax.php
@@ -164,6 +164,53 @@ class Test_CMB2_Ajax extends CMB2TestCase {
 	}
 
 	/**
+	 * oembed_handler() reads $_REQUEST['object_id'] directly. Without an isset()
+	 * guard, a request missing object_id emits an "Undefined array key" warning
+	 * (PHP 8+) — the same class of notice the field_id guard in this PR prevents.
+	 * The handler should reach wp_send_json_success() without a PHP warning.
+	 *
+	 * @group cmb2-ajax-embed
+	 */
+	public function test_oembed_handler_tolerates_missing_object_id() {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', array( $this, 'throw_oembed_die_handler' ), 99 );
+
+		$_REQUEST['cmb2_ajax_nonce'] = wp_create_nonce( 'ajax_nonce' );
+		$_REQUEST['oembed_url']      = $this->oembed_args['url'];
+		$_REQUEST['field_id']        = 'test_embed';
+		unset( $_REQUEST['object_id'] ); // The param under test is intentionally absent.
+
+		$reached_send_json = false;
+		$json              = '';
+
+		ob_start();
+		try {
+			cmb2_ajax()->oembed_handler();
+		} catch ( CMB2_Test_Oembed_Die $e ) {
+			$reached_send_json = true;
+			$json              = ob_get_contents();
+		} finally {
+			ob_end_clean();
+			unset( $_REQUEST['cmb2_ajax_nonce'], $_REQUEST['oembed_url'], $_REQUEST['field_id'] );
+		}
+
+		$this->assertTrue( $reached_send_json, 'oembed_handler() should reach wp_send_json_success() without a PHP warning when object_id is missing.' );
+
+		$decoded = json_decode( $json, true );
+		$this->assertTrue( ! empty( $decoded['success'] ), 'Handler should return a successful JSON response.' );
+	}
+
+	/**
+	 * Returns a wp_die handler (for the wp_die_ajax_handler filter) that throws a
+	 * marker exception, letting the test observe that wp_die() was reached.
+	 */
+	public function throw_oembed_die_handler() {
+		return function () {
+			throw new CMB2_Test_Oembed_Die();
+		};
+	}
+
+	/**
 	 * @group cmb2-ajax-embed
 	 */
 	public function test_values_cached() {
@@ -218,3 +265,9 @@ class Test_CMB2_Ajax extends CMB2TestCase {
 	}
 
 }
+
+/**
+ * Marker exception thrown by the test's wp_die handler so a test can assert that
+ * the AJAX handler reached wp_send_json_*() (which terminates via wp_die()).
+ */
+class CMB2_Test_Oembed_Die extends \Exception {}

--- a/tests/test-cmb-ajax.php
+++ b/tests/test-cmb-ajax.php
@@ -143,6 +143,27 @@ class Test_CMB2_Ajax extends CMB2TestCase {
 	}
 
 	/**
+	 * The field_id is reflected into the rel="" attribute of the remove-embed
+	 * link, so it must be escaped with esc_attr() to prevent it breaking out of
+	 * the attribute (XSS / WP Plugin Check violation).
+	 *
+	 * @group cmb2-ajax-embed
+	 */
+	public function test_get_oembed_escapes_field_id_in_rel_attribute() {
+		$args = $this->oembed_args;
+		$args['field_id'] = 'evil" onmouseover="alert(1)';
+		unset( $args['src'] );
+
+		$actual = cmb2_ajax()->get_oembed( $args );
+
+		// The attribute-breaking value must not be reflected verbatim.
+		$this->assertStringNotContainsString( 'rel="evil" onmouseover="alert(1)"', $actual );
+
+		// It must appear in its escaped form instead.
+		$this->assertStringContainsString( 'rel="' . esc_attr( $args['field_id'] ) . '"', $actual );
+	}
+
+	/**
 	 * @group cmb2-ajax-embed
 	 */
 	public function test_values_cached() {

--- a/tests/test-cmb-ajax.php
+++ b/tests/test-cmb-ajax.php
@@ -62,7 +62,34 @@ class Test_CMB2_Ajax extends CMB2TestCase {
 	public function tear_down() {
 		delete_option( $this->oembed_args['object_id'] );
 		remove_filter( 'pre_http_request', array( $this, 'mock_oembed_request' ), 10 );
+
+		// Reset the CMB2_Ajax singleton's per-request state so it does not leak
+		// into later tests/classes. get_oembed()/oembed_handler() set ajax_update,
+		// hijack, object_id/type and register the hijack_* metadata filters on the
+		// shared instance; left dirty, they can flip a later network-dependent
+		// oEmbed test onto its fallback path.
+		$this->reset_cmb2_ajax_state();
+
 		parent::tear_down();
+	}
+
+	/**
+	 * Clears the CMB2_Ajax singleton's mutable state and the metadata filters it
+	 * registers, restoring constructor defaults between tests.
+	 */
+	protected function reset_cmb2_ajax_state() {
+		$ajax = cmb2_ajax();
+
+		remove_filter( 'get_post_metadata', array( $ajax, 'hijack_oembed_cache_get' ), 10 );
+		remove_filter( 'update_post_metadata', array( $ajax, 'hijack_oembed_cache_set' ), 10 );
+
+		$reset = Closure::bind( function () {
+			$this->hijack      = false;
+			$this->object_id   = 0;
+			$this->object_type = 'post';
+			$this->ajax_update = false;
+		}, $ajax, CMB2_Ajax::class );
+		$reset();
 	}
 
 	/**


### PR DESCRIPTION
Hey folks,

Two related issues in `CMB2_Ajax::oembed_handler()` and `get_oembed()`:

1. `$_REQUEST['field_id']` is accessed without an `isset()` guard (PHP notice if absent) and without `sanitize_text_field()`/`wp_unslash()` before passing it into the embed args array.

2. In `get_oembed()`, that value is concatenated directly into an HTML `rel` attribute — `rel="' . $oembed['args']['field_id'] . '"` — without `esc_attr()`. WordPress Plugin Check flags this, and it's a reflected XSS vector for any admin with access to an oEmbed field.

Two-line fix: `isset()` + `sanitize_text_field( wp_unslash() )` at input, `esc_attr()` at the `rel` attribute on output.

(full disclosure, I used AI help with the testing and tweaks - Christopher)
